### PR TITLE
Glm adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _targets
 
 # User-specific files
 .Ruserdata
+.Rprofile
 
 # Example code in package build process
 *-Ex.R

--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -37,6 +37,8 @@ munge_nmls <- function(nml_list_rds, lake_ids, base_nml) {
       nml <- purrr::list_modify(nml, !!!adjust_depth_args_nml(nml))
       # set meteo_fl value to NULL
       nml <- purrr::list_modify(nml, !!!c('meteo_fl' = 'NULL'))
+      # disable evaporation
+      nml <- purrr::list_modify(nml, !!!c('disable_evap' = TRUE))
       # remove helpful but non-nml values
       nml <- nml[!(names(nml) %in% c('site_id'))]
       # merge into base nml, checking arguments along the way

--- a/2_run.R
+++ b/2_run.R
@@ -9,6 +9,8 @@ p2 <- list(
       sim_dir = '2_run/tmp',
       nml_objs = p1_nml_objects,
       model_config = p1_model_config,
+      burn_in = 10, #300,
+      burn_out = 10, #190,
       export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather'),
     packages = c('retry','glmtools', 'GLM3r'),
     pattern = map(p1_model_config)),

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -12,7 +12,7 @@
 #'  @param burn_out length of burn-out period, in days
 #'  @return a munged dataframe of meteorological data that includes
 #'  burn-in and burn-out time
-munge_meteo_w_burn_in_out <- function(model_config, begin, end, burn_in, burn_out){
+munge_meteo_w_burn_in_out <- function(model_config, begin, end, burn_in = 300, burn_out = 190){
   meteo_data <- arrow::read_feather(model_config$meteo_fl) %>%
     mutate(time = as.Date(time)) %>% filter(time >= as.Date(begin) & time <= as.Date(end)) %>%
     mutate(Rain = case_when(Snow > 0 ~ 0, TRUE ~ Rain))

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -131,6 +131,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, export_fl_template) 
         export_fl = export_fl,
         export_fl_hash = tools::md5sum(export_fl),
         glm_run_date = Sys.time(),
+        glm_version = GLM3r::glm_version(as_char = TRUE), #Needs version 3.1.18 of GLM3r
         glm_time_s = glm_time,
         glm_success = TRUE,
         glm_code = glm_code)
@@ -147,6 +148,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, export_fl_template) 
         export_fl = NA,
         export_fl_hash = NA,
         glm_run_date = Sys.time(),
+        glm_version = GLM3r::glm_version(as_char = TRUE), #Needs version 3.1.18 of GLM3r
         glm_time_s = glm_time,
         glm_success = FALSE,
         glm_code = glm_code)


### PR DESCRIPTION
This PR makes a few adjustments to our GLM set-up, based on feedback from Jordan.

* Adds the glm version to the export tibble produced by building `p2_glm_uncalibrated_runs` - fixes #8 
* Disables evap, per [this comment](https://github.com/USGS-R/lake-temperature-process-models/pull/6#issuecomment-995756465) on #6 
* Adds check of the length of the driver data when burn-in/burn-out is requested, and only adds either if the requested burn in/out period is <= the length of the driver data, per [this comment](https://github.com/USGS-R/lake-temperature-process-models/pull/6#issuecomment-995756465) on #6. Includes a message to alert the user
* Adds a second metric for determining that a model run is successful -- checking that the final date in the model output corresponds to the specified simulation end date, per [this comment](https://github.com/USGS-R/lake-temperature-process-models/issues/9#issuecomment-995928569) in #9 