### PR TITLE
set option for clustermq scheduler

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -1,4 +1,5 @@
 library(targets)
+options(clustermq.scheduler = "multicore")
 
 suppressPackageStartupMessages(library(tidyverse))
 tar_option_set(packages = c('tidyverse', 'ncdf4', 'ncdf4.helpers', 'arrow'))


### PR DESCRIPTION
Merge in Jesse's edit to the code on Denali that sets the `clustermq.scheduler` option within `_targets.R` so that `targets` can build targets in parallel within a single container on a single node on Denali, using the `tar_make_clustermq()` command.