### PR TITLE
Add code to catch errors in extracting model output

### DIFF
--- a/2_run.R
+++ b/2_run.R
@@ -3,10 +3,11 @@ source('2_run/src/run_glm3.R')
 p2 <- list(
   # Function will generate file
   # but return a tibble that includes that filename and its hash
+  # put simulation directories in sub-directory for easy deletion
   tar_target(
     p2_glm_uncalibrated_runs,
     run_glm3_model(
-      sim_dir = '2_run/tmp',
+      sim_dir = '2_run/tmp/simulations',
       nml_objs = p1_nml_objects,
       model_config = p1_model_config,
       burn_in = 300,

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -204,7 +204,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
         burn_out = burn_out,
         export_fl = NA,
         export_fl_hash = NA,
-        extraction_error = ifelse(exists("extraction_error"), extraction_error, NA),
+        extraction_error = ifelse(exists("extraction_error"), extraction_error, NA), # If the error happened prior to the attempt at extraction, need to provide an NA here
         glm_run_date = Sys.time(),
         glm_version = GLM3r::glm_version(as_char = TRUE), #Needs version 3.1.18 of GLM3r
         glm_time_s = glm_time,

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -91,8 +91,6 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
   # prepare to write inputs and results locally for quick I/O
   sim_lake_dir <- file.path(sim_dir, sprintf('%s_%s_%s', site_id, gcm, time_period))
   dir.create(sim_lake_dir, recursive=TRUE, showWarnings=FALSE)
-  # delete sim_lake_dir after model has run and we've extracted the results
-  on.exit(unlink(sim_lake_dir, recursive = TRUE))
   
   # read in meteo_data, add burn in and burn out, and save to sim_lake_dir
   meteo_data <- add_burn_in_out_to_meteo(raw_meteo_fl, burn_in = burn_in, burn_out = burn_out)
@@ -133,20 +131,41 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
           glm_time <- system.time({glm_code <- GLM3r::run_glm(sim_lake_dir, verbose = FALSE)})[['elapsed']]
           # Pull out the final date from the output to
           # check against requested simulation end date
-          output_dates <- glmtools::get_temp(nc_filepath) %>%
+          # use 1D variable 'evap' rather than 2D 'temp' to check output dates because
+          # 1) less expensive to pull and 2) defaults cause an error with glmtools::get_temp()
+          # when the lake is too shallow.
+          output_dates <- glmtools::get_var(nc_filepath, var_name = 'evap') %>%
             mutate(date = format(as.Date(lubridate::floor_date(DateTime, 'days')),"%Y-%m-%d")) %>%
             pull(date)
           max_output_date <- max(output_dates)
         },
         until=function(val, cnd) glm_code == 0 & max_output_date==sim_stop,
         max_tries = 5)
-
+      
       # make sure glm did succeed  
       if(glm_code != 0 | max_output_date!=sim_stop) stop()
       
       # extract output
       export_fl <- sprintf(export_fl_template, site_id, gcm, time_period)
-      extract_glm_output(nc_filepath, nml_obj, export_fl)
+      extraction_error <- tryCatch(
+        {
+          extract_glm_output(nc_filepath, nml_obj, export_fl)
+          extraction_error <- NA
+        },
+        error = function(e) {
+          if (grepl(e$message, 'need at least two non-NA values to interpolate')) {
+            extraction_error <- 'NA values'
+          } else {
+            extraction_error <- e$message
+          }
+          return(extraction_error)
+        }
+      )
+      # If extraction error is NOT NA, trigger error
+      if (!is.na(extraction_error)) stop()
+      
+      # If output was extracted, delete simulation directory
+      unlink(sim_lake_dir, recursive = TRUE)
       
       # Build export tibble with export file, its hash, and glm run information
       export_tibble <- tibble(
@@ -158,6 +177,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
         burn_out = burn_out,
         export_fl = export_fl,
         export_fl_hash = tools::md5sum(export_fl),
+        extraction_error = extraction_error,
         glm_run_date = Sys.time(),
         glm_version = GLM3r::glm_version(as_char = TRUE), #Needs version 3.1.18 of GLM3r
         glm_time_s = glm_time,
@@ -181,6 +201,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
         burn_out = burn_out,
         export_fl = NA,
         export_fl_hash = NA,
+        extraction_error = ifelse(exists("extraction_error"), extraction_error, NA),
         glm_run_date = Sys.time(),
         glm_version = GLM3r::glm_version(as_char = TRUE), #Needs version 3.1.18 of GLM3r
         glm_time_s = glm_time,

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -165,6 +165,8 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
       if (!is.na(extraction_error)) stop()
       
       # If output was extracted, delete simulation directory
+      # We are _not_ deleting the simulation directory for failed
+      # runs so that we can explore the model output
       unlink(sim_lake_dir, recursive = TRUE)
       
       # Build export tibble with export file, its hash, and glm run information

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -162,6 +162,7 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
         }
       )
       # If extraction error is NOT NA, trigger error
+      # and return the error export_tibble
       if (!is.na(extraction_error)) stop()
       
       # If output was extracted, delete simulation directory


### PR DESCRIPTION
Worked with Lindsay to account for errors where the GLM model runs (`glm_code`==0 and `max_output_date` = `param_sim_stop`, but there is an error when we go to [extract the output](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/add_extraction_error/2_run/src/run_glm3.R#L51-L61).

This code
* Nests the extraction attempt within a `tryCatch()` and logs an `extraction_error` variable to track whether or not that attempt errored
* Makes a change to only delete simulation directories if the model output was successfully extracted, and places simulation directories within a subfolder of `2_run/tmp` for easy deletion, per Jordan's suggestion.
* Switches to pulling the 'evap' variable rather than temperature to check the latest output dates, because 1) evap is 1D and 2) defaults cause an error with `glmtools::get_temp()` when the lake is too shallow.