### PR TITLE
Add initial code that resamples all hypsos to 1-m intervals

### DIFF
--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -11,7 +11,12 @@ adjust_depth_args_nml <- function(nml_args) {
     
     # &morphometry
     lake_name = site_id,
-    bsn_vals = length(H),
+    # for now, resample all hypso to 1-m intervals.
+    # returns new H,A vectors and bsn_vals
+    # should refine to only resample for lakes > a 
+    # certain depth, and return bsn_vals = length(H)
+    # for lakes shallower than that threshold depth
+    resample_H_A(H, A),
     
     # &init_profiles
     tibble(
@@ -46,4 +51,28 @@ munge_nmls <- function(nml_list_rds, site_ids, base_nml) {
     })
   
   return(nml_objs)
+}
+
+#' @Title Resample incoming hypsography to 1-m intervals
+#' @decription Resample the H and A values to 1-meter intervals; calc bsn_vals
+#' @param H the vector of H (elevation) values from the lake-specific 
+#' nml parameters loaded in from the nml_list.rds from lake-temperature-model-prep
+#' @param A the vector of A (area) values from the lake-specific nml 
+#' parameters loaded in from the nml_list.rds from lake-temperature-model-prep
+#' @return a list containing H and A vectors and a bsn_vals scaler
+resample_H_A <- function(H, A) {
+  ha_df <- tibble(H = H,A = A) %>%
+    arrange(H)
+  
+  # Resample hypso to 1-meter intervals
+  # Add an additional row for the deepest (final) raw H value so we don’t 
+  # end up with with a lake shallower than the lake depth param. 
+  # Then remove duplicate rows if any exist, which they will if the
+  # final H value from the raw H vector is an integer
+  ha_df_resampled <- bind_rows(tibble(H=seq.int(floor(min(ha_df$H)), floor(max(ha_df$H))),
+                                      A=approx(ha_df$H, ha_df$A, xout=seq.int(floor(min(ha_df$H)), floor(max(ha_df$H))), rule=2)$y),
+                               tibble(A=approx(H, A, xout=max(ha_df$H), rule=2)$y, H=max(ha_df$H))) %>%
+    distinct()
+  
+  c(ha_df_resampled, bsn_vals = nrow(ha_df_resampled))
 }


### PR DESCRIPTION
In digging into the [initial failed model runs](https://github.com/USGS-R/lake-temperature-process-models/issues/17#issuecomment-1024327315) Jordan and I did some testing and it seemed that the hypsography for some lakes may be _too_ finely resolved, which Jordan has had cause segmentation faults when running GLM in the past. To test this I added in this code, which adds a step to resample the hypsography to 1-m intervals when the nmls are being modified. This is a bandaid that is [gettting us more successful model runs](https://github.com/USGS-R/lake-temperature-process-models/issues/17#issuecomment-1024410663) for now, but eventually, we'll need to [incorporate a robust solution into `lake-temperature-model-prep`](https://github.com/USGS-R/lake-temperature-model-prep/issues/293) so that this issue is resolved there, where the nml information is first pulled together.