### PR TITLE
Edit packaging code

### DIFF
--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -16,7 +16,7 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
   # Build tibble of meteo files, branches, hashes, gcm name, cell_no, and time_period
   meteo_branches <- tibble(
     meteo_fl = meteo_feathers,
-    meteo_fl_hash = map_chr(names(meteo_feathers), ~ tar_meta(starts_with(.x))$data),
+    meteo_fl_hash = tools::md5sum(meteo_feathers),
     gcm = stringr::str_extract(meteo_fl, gcm_name_list),
     time_period = stringr::str_extract(meteo_fl, gcm_date_list),
     # cell_no is the very last part of the file name and so this str_extract() is 

--- a/3_extract.R
+++ b/3_extract.R
@@ -3,17 +3,27 @@ source('3_extract/src/process_glm_output.R')
 p3 <- list(
   # Use grouped target to combine glm output into feather files
   # Function will generate the output feather file for each lake-gcm combo
-  # but return a tibble that includes the filename and its hash
   tar_target(
     p3_glm_uncalibrated_output_feathers,
-    combine_glm_output(p2_glm_uncalibrated_run_groups, p1_lake_cell_tile_xwalk_df, 
+    combine_glm_output(p2_glm_uncalibrated_run_groups, 
                        outfile_template='3_extract/out/GLM_%s_%s.feather'),
+    format = 'file',
     pattern = map(p2_glm_uncalibrated_run_groups)),
   
-  # Group output feathers by tile number
+  # Generate a tibble with a row for each output file
+  # that includes the filename and its hash along with the
+  # site_id, gcm, the state the lake is in, and the cell_no 
+  # and tile_no for that lake.
+  tar_target(
+    p3_glm_uncalibrated_output_feather_tibble,
+    generate_output_tibble(p2_glm_uncalibrated_run_groups, p3_glm_uncalibrated_output_feathers, p1_lake_cell_tile_xwalk_df),
+    pattern = map(p2_glm_uncalibrated_run_groups, p3_glm_uncalibrated_output_feathers)
+  ),
+  
+  # Group output feather tibble by tile number
   tar_target(
     p3_glm_uncalibrated_output_feather_groups,
-    p3_glm_uncalibrated_output_feathers %>%
+    p3_glm_uncalibrated_output_feather_tibble %>%
       group_by(tile_no) %>%
       tar_group(),
     iteration = "group"

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -2,7 +2,7 @@
 #' @description function to read in the raw output from the 3 GLM
 #' runs for each fully successful lake-gcm combo (set by grouping of 
 #' `p2_glm_uncalibrated_run_groups`), filter that output to the 
-#' burn-out periods), and save the result as a single feather file
+#' burn-out periods, and save the result as a single feather file
 #' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
 #' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
 #' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
@@ -36,11 +36,10 @@ combine_glm_output <- function(run_group, outfile_template) {
 #' @title Generate a tibble of information about the output
 #' feather files
 #' @description Generate a tibble with a row for each output file
-#' that includes its filename and its hash along with the
-#' site_id, gcm, the state the lake is in, and the cell_no 
-#' and tile_no for that lake. Use the lake_cell_tile_xwalk to determine 
-#' which tile each lake falls into, and then group the feather files
-#' (unique to each lake-gcm combo) by tile_no
+#' (unique to each lake-gcm combo) that includes its filename and its 
+#' hash along with the site_id, gcm, the state the lake is in, and 
+#' the cell_no and tile_no for that lake. Use the lake_cell_tile_xwalk 
+#' to determine which tile each lake falls into
 #' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
 #' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
 #' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
@@ -48,7 +47,8 @@ combine_glm_output <- function(run_group, outfile_template) {
 #' only groups for which glm_success==TRUE for all runs in that group. 
 #' The function maps over these groups.
 #' @param output_feather A single feather file name from the list of 
-#' output feather file names. The function maps over these file names.
+#' output feather file names returned by `combine_glm_output()`. 
+#' The function maps over these file names.
 #' @param lake_cell_tile_xwalk - mapping of which lakes fall into which 
 #' gcm cells and tiles
 #' @return A tibble with one row per lake-gcm output feather file which 
@@ -70,10 +70,10 @@ generate_output_tibble <- function(run_group, output_feather, lake_cell_tile_xwa
 #' @title Zip up output from GLM model runs
 #' @description function to zip up the feather files for all lake-gcm
 #' combos according to the tile_no associated with each lake
-#' @param feather_group A single group associated with one tile, from the 
-#' `p3_glm_uncalibrated_output_feather_groups` grouped version of the 
-#' `p3_glm_uncalibrated_output_feather_tibble` target grouped by tile_no.
-#' The function maps over these groups.
+#' @param feather_group A single group of output feather files associated 
+#' with one tile, from the `p3_glm_uncalibrated_output_feather_groups` 
+#' grouped version of the `p3_glm_uncalibrated_output_feather_tibble` 
+#' target grouped by tile_no. The function maps over these groups.
 #' @param zipfile_template the template for the name of the
 #' final zipped file of feather files
 #' @return the name of the zipped file 

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -1,30 +1,26 @@
 #' @title Combine output from GLM model runs
-#' @description function to read in the raw output from the GLM
-#' runs for each lake-gcm combo (set by grouping of 
-#' `p2_glm_uncalibrated_run_groups`) for each time period, filter 
-#' that output to the valid dates within each time period 
-#' (excluding the burn-in and burn-out periods), and save the
-#' result as a single feather file
-#' @param run_groups a grouped version of the `p2_glm_uncalibrated_runs`
-#' output tibble subset to the site_id, gcm, time_period, raw_meteo_fl, 
-#' export_fl, and export_fl_hash columns and grouped by site_id and gcm.
-#' Then filtered to only groups for which glm_success==TRUE for all runs
-#' in that group. The function maps over these groups.
-#' @param lake_cell_tile_xwalk - mapping of which lakes fall into which 
-#' gcm cells and tiles
+#' @description function to read in the raw output from the 3 GLM
+#' runs for each fully successful lake-gcm combo (set by grouping of 
+#' `p2_glm_uncalibrated_run_groups`), filter that output to the 
+#' burn-out periods), and save the result as a single feather file
+#' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
+#' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
+#' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
+#' export_fl_hash columns and grouped by site_id and gcm. Then filtered to 
+#' only groups for which glm_success==TRUE for all runs in that group. 
+#' The function maps over these groups.
 #' @param outfile_template the template for the name of the
 #' final output feather file
-#' @return a tibble with one row per lake-gcm combo which includes the 
-#' site_id, gcm, the name of the export feather file, its hash, the state 
-#' the lake is in, and the cell_no and tile_no for the GCM data for that lake. 
-combine_glm_output <- function(run_groups, lake_cell_tile_xwalk, outfile_template) {
+#' @return a single feather file with the output data for that lake-gcm
+#' combo, filtered to the valid dates from each time period
+combine_glm_output <- function(run_group, outfile_template) {
   # set filename
-  outfile <- sprintf(outfile_template, unique(run_groups$site_id), unique(run_groups$gcm))
+  outfile <- sprintf(outfile_template, unique(run_group$site_id), unique(run_group$gcm))
   
   # combine into single feather file and write
   # truncating output for each time period to valid dates
   # (excluding burn-in and burn-out periods)
-  purrr::map2_df(run_groups$raw_meteo_fl, run_groups$export_fl, function(raw_meteo_fl, export_file) {
+  purrr::map2_df(run_group$raw_meteo_fl, run_group$export_fl, function(raw_meteo_fl, export_file) {
     # Define time period begin and end dates from raw meteo_fl
     meteo_data <- arrow::read_feather(raw_meteo_fl, col_select = "time")
     begin <- min(meteo_data$time)
@@ -34,27 +30,56 @@ combine_glm_output <- function(run_groups, lake_cell_tile_xwalk, outfile_templat
       filter(time >= as.Date(begin) & time <= as.Date(end))
   }) %>% arrow::write_feather(outfile)
   
+  return(outfile)
+}
+
+#' @title Generate a tibble of information about the output
+#' feather files
+#' @description Generate a tibble with a row for each output file
+#' that includes its filename and its hash along with the
+#' site_id, gcm, the state the lake is in, and the cell_no 
+#' and tile_no for that lake. Use the lake_cell_tile_xwalk to determine 
+#' which tile each lake falls into, and then group the feather files
+#' (unique to each lake-gcm combo) by tile_no
+#' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
+#' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
+#' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
+#' export_fl_hash columns and grouped by site_id and gcm. Then filtered to 
+#' only groups for which glm_success==TRUE for all runs in that group. 
+#' The function maps over these groups.
+#' @param output_feather A single feather file name from the list of 
+#' output feather file names. The function maps over these file names.
+#' @param lake_cell_tile_xwalk - mapping of which lakes fall into which 
+#' gcm cells and tiles
+#' @return A tibble with one row per lake-gcm output feather file which 
+#' includes the site_id, gcm, the name of the export feather file, its 
+#' hash, the state the lake is in, and the cell_no and tile_no for the 
+#' GCM data for that lake. 
+generate_output_tibble <- function(run_group, output_feather, lake_cell_tile_xwalk) {
   export_tibble <- tibble(
-    site_id = unique(run_groups$site_id),
-    gcm = unique(run_groups$gcm),
-    export_fl = outfile,
-    export_fl_hash = tools::md5sum(outfile),
-  ) %>%
-    left_join(lake_cell_tile_xwalk, by=c('site_id'))
+      site_id = unique(run_group$site_id),
+      gcm = unique(run_group$gcm),
+      export_fl = output_feather,
+      export_fl_hash = tools::md5sum(output_feather)
+    ) %>% 
+    left_join(lake_cell_tile_xwalk, by='site_id')
+  
   return(export_tibble)
 }
 
 #' @title Zip up output from GLM model runs
-#' @description function to zip up the feather files for each lake-gcm
-#' combo according to the tile_no associated with that lake
-#' @param feather_groups a grouped version of the `p3_glm_uncalibrated_output_feathers`
-#' output tibble grouped by tile_no. The function maps over these groups.
+#' @description function to zip up the feather files for all lake-gcm
+#' combos according to the tile_no associated with each lake
+#' @param feather_group A single group associated with one tile, from the 
+#' `p3_glm_uncalibrated_output_feather_groups` grouped version of the 
+#' `p3_glm_uncalibrated_output_feather_tibble` target grouped by tile_no.
+#' The function maps over these groups.
 #' @param zipfile_template the template for the name of the
 #' final zipped file of feather files
 #' @return the name of the zipped file 
-zip_output_files <- function(feather_groups, zipfile_template) {
-  files_to_zip <- feather_groups$export_fl
-  zipfile_out <- sprintf(zipfile_template, unique(feather_groups$tile_no))
+zip_output_files <- function(feather_group, zipfile_template) {
+  files_to_zip <- feather_group$export_fl
+  zipfile_out <- sprintf(zipfile_template, unique(feather_group$tile_no))
   # In order to use `zip`, you need to be in the same working directory as
   # the files you want to zip up.
   project_dir <- getwd()


### PR DESCRIPTION
Revise `3_extract` step to separate a) output feather file creation from b) grouping those files in preparation for zipping. That way, if we want to change out the output files are grouped, we can do so without re-writing those output files.

Note 1 - I had to split b) into two steps. One to generate the tibble with file names and hashes, and a second to group that tibble by `tile_no`. When I tried it in a single step, `targets` didn't seem to be able to do the `tar_group()`-ing while also mapping over upstream targets.

Note 2 - I noticed while in the code that while building `p1_model_config` and pulling the hash for the meteo feathers  I was still using [Alison's code from `res-temperature-process-models`](https://code.usgs.gov/wma/wp/res-temperature-process-models/-/blob/main/2_prep/src/munge_meteo.R#L24), which was set up to hash `targets` objects. Since we ended up using feather files instead I switched the hash to our standard `tools::md5sum()`.