### PR TITLE
change order of gcm name and site id in outfile file name template

### DIFF
--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -19,7 +19,7 @@
 #' the lake is in, and the cell_no and tile_no for the GCM data for that lake. 
 combine_glm_output <- function(run_groups, lake_cell_tile_xwalk, outfile_template) {
   # set filename
-  outfile <- sprintf(outfile_template, unique(run_groups$site_id), unique(run_groups$gcm))
+  outfile <- sprintf(outfile_template, unique(run_groups$gcm), unique(run_groups$site_id))
   
   # combine into single feather file and write
   # truncating output for each time period to valid dates


### PR DESCRIPTION
Tiny edit to switch the GLM output naming convention from `'GLM_{site_id}_{GCM name}.feather'` to `'GLM_{GCM name}_{site id}.feather'` to aid with regex work in `lake-temperature-out`

_Note: to be consistent, we could also change the naming conventions for the temporary feather files generated for each lake-gcm-time-period combo during model execution [here](https://github.com/USGS-R/lake-temperature-process-models/blob/main/2_run/src/run_glm3.R#L149), but I'm not making that change now as it would trigger a full rebuild of the models, as opposed to just regenerating the output feathers for each lake-gcm combo by rebuilding `p3_glm_uncalibrated_output_feathers`_