### PR TITLE
Fix nml object use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ _targets
 */tmp/*
 */out/*
 
+# Allow the nml template to be committed
+!1_prep/in/glm3_template.nml
+
 # Allow the `.empty` files to be committed
 !*/in/.empty
 !*/tmp/.empty

--- a/1_prep.R
+++ b/1_prep.R
@@ -60,6 +60,7 @@ p1 <- list(
              munge_nmls(nml_list_rds = p1_nml_list_rds,
                         site_ids = p1_site_ids,
                         base_nml = p1_glm_template_nml),
-             packages = c('glmtools'))
+             packages = c('glmtools'),
+             iteration = 'list')
 )
 

--- a/1_prep/in/glm3_template.nml
+++ b/1_prep/in/glm3_template.nml
@@ -1,0 +1,143 @@
+&glm_setup
+   sim_name = 'GLMSimulation'
+   max_layers = 700
+   min_layer_vol = 0.5
+   min_layer_thick = 0.15
+   max_layer_thick = 0.5
+   density_model = 1
+   non_avg = .true.
+/
+&mixing
+  surface_mixing = 1
+  coef_mix_conv = 0.125
+  coef_wind_stir = 0.23
+  coef_mix_shear = 0.2
+  coef_mix_turb = 0.51
+  coef_mix_KH = 0.3
+  deep_mixing = 2
+  coef_mix_hyp = 0.5
+  diff = 0.
+/
+&morphometry
+   lake_name = 'template'
+   latitude = 46.00881
+   longitude = -89.69953
+   bsn_len = 901.0385
+   bsn_wid = 901.0385
+   !crest_elev = 320.
+   !base_elev = 280.
+   bsn_vals = 2
+   H = 301.712, 321
+   A = 0, 687641.569
+/
+&time
+   timefmt = 2
+   start = '2000-04-15'
+   stop = '2000-12-10'
+   dt = 3600
+   timezone = -6
+   num_days = 150
+/
+&output
+   out_dir = 'out'
+   out_fn = 'output'
+   nsave = 24
+   csv_lake_fname = 'lake'
+   csv_point_nlevs = 0
+   csv_point_fname = 'WQ_'
+   csv_point_at = 17
+   csv_point_nvars = 2
+   csv_point_vars = 'temp','salt','OXY_oxy'
+   csv_outlet_allinone = .false.
+   csv_outlet_fname = 'outlet_'
+   csv_outlet_nvars = 2
+   csv_outlet_vars = 'flow','temp','salt','OXY_oxy'
+   csv_ovrflw_fname = 'overflow'
+/
+&init_profiles
+   lake_depth = 18.288
+   num_depths = 2
+   the_depths = 0,18.288
+   the_temps = 3, 4
+   the_sals = 0, 0
+   num_wq_vars = 0
+   wq_names = 'OGM_don','OGM_pon','OGM_dop','OGM_pop','OGM_doc','OGM_poc'
+   wq_init_vals =  1.1, 1.2, 2.2, 1.3, 3.3, 4.1,1.1, 1.2, 2.2, 1.3, 3.3, 4.1
+/
+&meteorology
+   met_sw = .true.
+   lw_type = 'LW_IN'
+   rain_sw = .false.
+   atm_stab = 0
+   catchrain = .false.
+   rad_mode = 1
+   albedo_mode = 1
+   cloud_mode = 4
+   fetch_mode = 0
+   subdaily = .false.
+   meteo_fl = 'met_hourly.csv'
+   wind_factor = 1
+   sw_factor = 1
+   lw_factor = 1
+   at_factor = 1
+   rh_factor = 1
+   rain_factor = 1
+   ce = 0.0013
+   ch = 0.0013
+   cd = 0.0013
+   rain_threshold = 0.01
+   runoff_coef = 0.3
+/
+&bird_model
+   AP = 973
+   Oz = 0.279
+   WatVap = 1.1
+   AOD500 = 0.033
+   AOD380 = 0.038
+   Albedo = 0.2
+/
+&light
+   light_mode = 0
+   n_bands = 4
+   light_extc = 1.0, 0.5, 2.0, 4.0
+   energy_frac = 0.51, 0.45, 0.035, 0.005
+   Benthic_Imin = 10
+   Kw = 0.331
+/
+&inflow
+   num_inflows = 0
+   names_of_strms = 'Riv1','Riv2'
+   !subm_flag = .false.
+   strm_hf_angle = 65, 65
+   strmbd_slope = 2, 2
+   strmbd_drag = 0.016, 0.016
+   !coef_inf_entrain = 0.
+   inflow_factor = 1, 1
+   inflow_fl = 'bcs/inflow_1.csv','bcs/inflow_2.csv'
+   inflow_varnum = 2
+   inflow_vars = 'FLOW','TEMP'
+   time_fmt = 'YYYY-MM-DD'
+/
+&outflow
+   num_outlet = 0
+   outflow_fl = 'in/outflow.csv'
+   !time_fmt = 'YYYY-MM-DD hh:mm:ss'
+   outflow_factor = 0.8
+   outflow_thick_limit = 100
+   !single_layer_draw = .false.
+   flt_off_sw = .false.
+   outlet_type = 1
+   outl_elvs = 1
+   bsn_len_outl = 5
+   bsn_wid_outl = 5
+   !crest_width = 100
+   !crest_factor = 0.61
+/
+&snowice
+   dt_iceon_avg = 0.01
+   min_ice_thickness = 0.01
+   snow_albedo_factor = 0.72
+/
+&debugging
+   disable_evap = .false.
+/

--- a/2_run.R
+++ b/2_run.R
@@ -6,13 +6,17 @@ p2 <- list(
   # put simulation directories in sub-directory for easy deletion
   tar_target(
     p2_glm_uncalibrated_runs,
-    run_glm3_model(
-      sim_dir = '2_run/tmp/simulations',
-      nml_obj = p1_nml_objects,
-      model_config = p1_model_config,
-      burn_in = 300,
-      burn_out = 190,
-      export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather'),
+    {
+      # check mapping to ensure is correct
+      tar_assert_identical(p1_model_config$site_id, p1_nml_objects$morphometry$lake_name, "p1_nml_object site id doesn't match p1_model_config site id")
+      run_glm3_model(
+        sim_dir = '2_run/tmp/simulations',
+        nml_obj = p1_nml_objects,
+        model_config = p1_model_config,
+        burn_in = 300,
+        burn_out = 190,
+        export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather')
+    },
     packages = c('retry','glmtools', 'GLM3r'),
     pattern = map(p1_model_config, cross(p1_nml_objects, p1_gcm_names, p1_gcm_dates))),
   

--- a/2_run.R
+++ b/2_run.R
@@ -8,13 +8,13 @@ p2 <- list(
     p2_glm_uncalibrated_runs,
     run_glm3_model(
       sim_dir = '2_run/tmp/simulations',
-      nml_objs = p1_nml_objects,
+      nml_obj = p1_nml_objects,
       model_config = p1_model_config,
       burn_in = 300,
       burn_out = 190,
       export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather'),
     packages = c('retry','glmtools', 'GLM3r'),
-    pattern = map(p1_model_config)),
+    pattern = map(p1_model_config, cross(p1_nml_objects, p1_gcm_names, p1_gcm_dates))),
   
   # Group model runs by lake id and gcm
   # Discard the glm diagnostics so they don't trigger rebuilds

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -66,7 +66,7 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
 #'  successful, the results are extracted and saved to '2_run/tmp' using
 #'  `extract_glm_ouput()` and then the simulation directory is deleted 
 #'  @param sim_dir base directory for simulations
-#'  @param nml_objs list of nml objects (one per lake id), named by lake id
+#'  @param nml_obj nml object for the current lake
 #'  @param model_config a lake-gcm-time_period crosswalk table with the 
 #'  meteo file name and hash for each model run
 #'  @param burn_in length of burn-in period, in days. Used to mirror the 
@@ -81,13 +81,13 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
 #'  the name of the export feather file, its hash (NA if the model run failed), 
 #'  the duration of the model run, whether or not the model run succeeded, 
 #'  and the code returned by the call to GLM3r::run_glm(). 
-run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, export_fl_template) {
-  # pull site_id from model_config
+run_glm3_model <- function(sim_dir, nml_obj, model_config, burn_in, burn_out, export_fl_template) {
+  # pull parameters from model_config
   site_id <- model_config$site_id
   time_period <- model_config$time_period
   gcm <- model_config$gcm
   raw_meteo_fl <- model_config$meteo_fl
-  
+
   # prepare to write inputs and results locally for quick I/O
   sim_lake_dir <- file.path(sim_dir, sprintf('%s_%s_%s', site_id, gcm, time_period))
   dir.create(sim_lake_dir, recursive=TRUE, showWarnings=FALSE)
@@ -102,7 +102,6 @@ run_glm3_model <- function(sim_dir, nml_objs, model_config, burn_in, burn_out, e
   sim_stop <- format(tail(meteo_data, 1L)$time, "%Y-%m-%d")
   
   # write nml file, specifying meteo file and start and stop dates:
-  nml_obj <- nml_objs[[site_id]]
   nml_obj <- set_nml(nml_obj, arg_list = list(nsave = 24, 
                                               meteo_fl = sim_meteo_filename,
                                               sim_name = sprintf('%s_%s_%s', site_id, gcm, time_period),


### PR DESCRIPTION
Fixes #22 

When I started to dig into #22, I realized that it was possible to make this fix without writing each of the nml objects to file, so I instead implemented an objects-based fix here.

This PR:
  * Adds list iteration to the `p1_nml_objects` list of nml objects
  * Maps over that `p1_nml_objects` in the target recipe for `p2_glm_uncalibrated_runs`, but does so as part of a `cross()` with `p1_gcm_names` and `p1_gcm_dates`, which means that each nml object is repeated 18 times - once for each gcm-time-period combination. That matches the [construction](https://github.com/USGS-R/lake-temperature-process-models/blob/main/1_prep/src/build_model_config.R#L32-L35) of `p1_model_config`, which means that the nml object passed to each branch of `p2_glm_uncalibrated_runs` is the correct nml object for that model run.

I tested this out for a subset of 5 lakes. If I first run the model for 4 of the lakes, and then add another site_id for a 5th lake, only the models for that 5th lake are built. Similarly if I run the model for 4 of the lakes and then _remove_ one of those site_ids, none of the models are rebuilt. That's the behavior we want, and corrects the issue noted in #22.