### PR TITLE
Update uses of cell_no and tile_no given new lake_cell_tile_xwalk

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -19,8 +19,8 @@ p1 <- list(
                arrange(site_id)),
 
   # Define mapping variables
-  tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df$site_id),
-  tar_target(p1_cell_nos, unique(p1_lake_cell_tile_xwalk_df$cell_no)),
+  tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
+  tar_target(p1_cell_nos, unique(p1_lake_cell_tile_xwalk_df %>% pull(data_cell_no))),
   tar_target(p1_gcm_names, c('ACCESS', 'GFDL', 'CNRM', 'IPSL', 'MRI', 'MIROC5')),
   tar_target(p1_gcm_dates, c('1980_1999', '2040_2059', '2080_2099')),
   

--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -5,6 +5,9 @@
 #' For the string extraction to work, cell_no must be at the END of the meteo filename
 #' @param meteo_feathers - names of the cell/gcm/time-period specific feather files
 #' @param lake_cell_tile_xwalk - mapping of which lakes fall into which gcm cells and tiles
+#' (parameters `spatial_cell_no` and `spatial_tile_no`) and which gcm cell to use for driver 
+#' data for each lake (`data_cell_no`,`data_tile_no`). `data_cell_no` will only differ from
+#' `spatial_cell_no` for those lakes that fall within gcm cells that are missing data.
 #' @param gcm_names - names of the 6 GCMs
 #' @param gcm_dates - the three GCM time periods, defined by their bracketing years
 #' @return a dplyr tibble with one row per model run
@@ -12,7 +15,7 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
   # collapse the gcm_names, gcm_date, and cell_no vectors for use in string matching
   gcm_name_list <- paste(gcm_names,collapse="|")
   gcm_date_list <- paste(gcm_dates,collapse="|")
-  cell_no_list <- paste(unique(lake_cell_tile_xwalk$cell_no),collapse= "|")
+  cell_no_list <- paste(unique(lake_cell_tile_xwalk$data_cell_no),collapse= "|")
   # Build tibble of meteo files, branches, hashes, gcm name, cell_no, and time_period
   meteo_branches <- tibble(
     meteo_fl = meteo_feathers,
@@ -25,18 +28,19 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
     cell_no = as.numeric(str_extract(tools::file_path_sans_ext(meteo_fl), paste0(cell_no_list, "$")))
   )
   # build model config table, with one row per lake-gcm-time-period combination
-  # and the `meteo_fl` filename and `meteo_fl_hash` for each model run. Leave out `cell_no`
+  # and the `meteo_fl` filename and `meteo_fl_hash` for each model run. Join the meteo
+  # files to the xwalk using the `data_cell_no` field from the xwalk, which indicates
+  # which gcm cell to use for driver data for each lake. Leave out `data_cell_no`
   # from the final tibble since it is not used during model execution and if changed,
   # should not trigger rebuilds unless the underlying data changes, which is 
   # captured by the `meteo_fl_hash` column
   model_config <- tidyr::expand_grid(
-    nesting(select(lake_cell_tile_xwalk, site_id, state, cell_no)),
+    nesting(select(lake_cell_tile_xwalk, site_id, state, data_cell_no)),
     gcm = gcm_names, 
     time_period = gcm_dates) %>%
-    dplyr::relocate(c(gcm, time_period), .before=cell_no) %>%
     arrange(site_id) %>%
-    left_join(meteo_branches, by=c('gcm', 'cell_no', 'time_period')) %>%
-    select(-cell_no) %>%
+    left_join(meteo_branches, by=c('gcm', 'data_cell_no'='cell_no', 'time_period')) %>%
+    select(-data_cell_no) %>%
     rowwise()
   return(model_config)
 }

--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -15,7 +15,7 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
   # collapse the gcm_names, gcm_date, and cell_no vectors for use in string matching
   gcm_name_list <- paste(gcm_names,collapse="|")
   gcm_date_list <- paste(gcm_dates,collapse="|")
-  cell_no_list <- paste(unique(lake_cell_tile_xwalk$data_cell_no),collapse= "|")
+  data_cell_no_list <- paste(unique(lake_cell_tile_xwalk$data_cell_no),collapse= "|")
   # Build tibble of meteo files, branches, hashes, gcm name, cell_no, and time_period
   meteo_branches <- tibble(
     meteo_fl = meteo_feathers,
@@ -25,11 +25,11 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
     # cell_no is the very last part of the file name and so this str_extract() is 
     # set up to use a regex that looks for a match in the last part of the filename 
     # just before the file extension
-    cell_no = as.numeric(str_extract(tools::file_path_sans_ext(meteo_fl), paste0(cell_no_list, "$")))
+    data_cell_no = as.numeric(str_extract(tools::file_path_sans_ext(meteo_fl), paste0(data_cell_no_list, "$")))
   )
   # build model config table, with one row per lake-gcm-time-period combination
-  # and the `meteo_fl` filename and `meteo_fl_hash` for each model run. Join the meteo
-  # files to the xwalk using the `data_cell_no` field from the xwalk, which indicates
+  # and the `meteo_fl` filename and `meteo_fl_hash` for each model run. We join the
+  # meteo files to the xwalk using the `data_cell_no` field b/c that field indicates
   # which gcm cell to use for driver data for each lake. Leave out `data_cell_no`
   # from the final tibble since it is not used during model execution and if changed,
   # should not trigger rebuilds unless the underlying data changes, which is 
@@ -39,7 +39,7 @@ build_model_config <- function(meteo_feathers, lake_cell_tile_xwalk, gcm_names, 
     gcm = gcm_names, 
     time_period = gcm_dates) %>%
     arrange(site_id) %>%
-    left_join(meteo_branches, by=c('gcm', 'data_cell_no'='cell_no', 'time_period')) %>%
+    left_join(meteo_branches, by=c('gcm', 'data_cell_no', 'time_period')) %>%
     select(-data_cell_no) %>%
     rowwise()
   return(model_config)

--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -25,7 +25,7 @@ adjust_depth_args_nml <- function(nml_args) {
 #' @decription Replace the NLDAS filename stored as 'meteo_fl'
 #' with 'NULL', remove used nml parameter 'site_id'
 #' @param nml_list_rds rds file of lake-specific nml parameters
-#' @param site_ids vector of lakes from lake_cell_xwalk
+#' @param site_ids vector of lakes from lake_cell_tile_xwalk
 #' @param base_nml glm3 nml template
 #' @return complete nml objects
 munge_nmls <- function(nml_list_rds, site_ids, base_nml) {

--- a/3_extract.R
+++ b/3_extract.R
@@ -10,11 +10,11 @@ p3 <- list(
                        outfile_template='3_extract/out/GLM_%s_%s.feather'),
     pattern = map(p2_glm_uncalibrated_run_groups)),
   
-  # Group output feathers by tile number
+  # Group output feathers by spatial tile number
   tar_target(
     p3_glm_uncalibrated_output_feather_groups,
     p3_glm_uncalibrated_output_feathers %>%
-      group_by(tile_no) %>%
+      group_by(spatial_tile_no) %>%
       tar_group(),
     iteration = "group"
   ),

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -10,13 +10,17 @@
 #' export_fl, and export_fl_hash columns and grouped by site_id and gcm.
 #' Then filtered to only groups for which glm_success==TRUE for all runs
 #' in that group. The function maps over these groups.
-#' @param lake_cell_tile_xwalk - mapping of which lakes fall into which 
-#' gcm cells and tiles
+#' @param lake_cell_tile_xwalk - mapping of which lakes fall into which gcm 
+#' cells and tiles (parameters `spatial_cell_no` and `spatial_tile_no`) and 
+#' which gcm cell to use for driver data for each lake (`data_cell_no`,
+#' `data_tile_no`). `data_cell_no` will only differ from `spatial_cell_no` 
+#' for those lakes that fall within gcm cells that are missing data.
 #' @param outfile_template the template for the name of the
 #' final output feather file
 #' @return a tibble with one row per lake-gcm combo which includes the 
 #' site_id, gcm, the name of the export feather file, its hash, the state 
-#' the lake is in, and the cell_no and tile_no for the GCM data for that lake. 
+#' the lake is in, and the GCM spatial_cell_no, spatial_tile_no, data_cell_no,
+#' and data_tile_no for that lake. 
 combine_glm_output <- function(run_groups, lake_cell_tile_xwalk, outfile_template) {
   # set filename
   outfile <- sprintf(outfile_template, unique(run_groups$site_id), unique(run_groups$gcm))
@@ -46,15 +50,15 @@ combine_glm_output <- function(run_groups, lake_cell_tile_xwalk, outfile_templat
 
 #' @title Zip up output from GLM model runs
 #' @description function to zip up the feather files for each lake-gcm
-#' combo according to the tile_no associated with that lake
+#' combo according to the spatial_tile_no associated with that lake
 #' @param feather_groups a grouped version of the `p3_glm_uncalibrated_output_feathers`
-#' output tibble grouped by tile_no. The function maps over these groups.
-#' @param zipfile_template the template for the name of the
-#' final zipped file of feather files
+#' output tibble grouped by spatial_tile_no. The function maps over these groups.
+#' @param zipfile_template the template for the name of the final zipped file
+#' of feather files, which will be customized with the spatial_tile_no
 #' @return the name of the zipped file 
 zip_output_files <- function(feather_groups, zipfile_template) {
   files_to_zip <- feather_groups$export_fl
-  zipfile_out <- sprintf(zipfile_template, unique(feather_groups$tile_no))
+  zipfile_out <- sprintf(zipfile_template, unique(feather_groups$spatial_tile_no))
   # In order to use `zip`, you need to be in the same working directory as
   # the files you want to zip up.
   project_dir <- getwd()


### PR DESCRIPTION
The new `lake_cell_tile_xwalk` [created in `lake-temperature-model-prep`](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R#L193-L205) contains two fields for both `cell_no` and `tile_no` -- a `spatial_X` and `data_X` field for each. The fields prefixed by `spatial_` indicate the cell and tile into which each lake falls spatially. The fields prefixed by `data_` indicate which cell and tile should be use for driver data for each lake. The `data_cell_no` will only differ from the `spatial_cell_no` for those lakes that fall within gcm cells that are missing data. The `data_tile_no` will only differ from the `spatial_tile_no` for those lakes that a) fall within gcm cells that are missing data, and b) are matched to a non-NaN cell in a different tile by our [matching code](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/7_drivers_munge/src/GCM_driver_utils.R#L195-L242).

In this repo, we now use the `data_cell_no` instead of just `cell_no` to determine which meteo file to use for each lake model.

And for our [temporary solution](https://github.com/USGS-R/lake-temperature-process-models/issues/31) of zipping the output feathers by tile number, we now use `spatial_tile_no` instead of just `tile_no`, since we are grouping the output spatially and providing a map to guide users:
![image](https://user-images.githubusercontent.com/54007288/156795554-fc501ea7-5d5a-45de-9ebf-40a555301c5a.png)
