### PR TITLE
Extract more output

### DIFF
--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -63,11 +63,11 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
     select(-DateTime)
   ice_data <- glmtools::get_var(nc_filepath, var_name = 'hice') %>%
     mutate(ice = hice > 0, time = as.Date(lubridate::ceiling_date(DateTime, ' days'))) %>%
-    select(-DateTime) 
-  all_results <- layers_data %>%
-    left_join(evap_data, ., by = 'time') %>%
-    left_join(ice_data, ., by = 'time') %>%
-    left_join(temp_data, ., by = 'time') %>%
+    select(-DateTime)
+  all_results <- temp_data %>%
+    left_join(ice_data, by = 'time') %>%
+    left_join(evap_data, by = 'time') %>%
+    left_join(layers_data, by = 'time') %>%
     select(time, everything()) %>%
     arrow::write_feather(export_fl)
 }

--- a/3_extract.R
+++ b/3_extract.R
@@ -3,6 +3,9 @@ source('3_extract/src/process_glm_output.R')
 p3 <- list(
   # Use grouped target to combine glm output into feather files
   # Function will generate the output feather file for each lake-gcm combo
+  # across all three time periods, truncating the output to the valid dates 
+  # for each time period (exluding the burn-in and burn-out periods) and
+  # saving only the temperature predictions for each depth and ice flags
   tar_target(
     p3_glm_uncalibrated_output_feathers,
     combine_glm_output(p2_glm_uncalibrated_run_groups, 

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -1,8 +1,11 @@
 #' @title Combine output from GLM model runs
 #' @description function to read in the raw output from the 3 GLM
 #' runs for each fully successful lake-gcm combo (set by grouping of 
-#' `p2_glm_uncalibrated_run_groups`), filter that output to the 
-#' burn-out periods, and save the result as a single feather file
+#' `p2_glm_uncalibrated_run_groups`), remove the ice thickness, 
+#' evaporation, and n_layers variables (leaving the temperature 
+#' predictions and ice flags), filter that output to exclude the
+#' burn-in and burn-out periods, and save the result as a single 
+#' feather file
 #' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
 #' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
 #' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
@@ -11,13 +14,15 @@
 #' The function maps over these groups.
 #' @param outfile_template the template for the name of the
 #' final output feather file
-#' @return a single feather file with the output data for that lake-gcm
-#' combo, filtered to the valid dates from each time period
+#' @return a single feather file with the output temperature predictions
+#' and ice flags for that lake-gcm combo, filtered to the valid dates 
+#' from each time period
 combine_glm_output <- function(run_group, outfile_template) {
   # set filename
   outfile <- sprintf(outfile_template, unique(run_group$site_id), unique(run_group$gcm))
   
-  # combine into single feather file and write
+  # combine into single feather file and write,
+  # saving only the temperature predictions and ice flags, and
   # truncating output for each time period to valid dates
   # (excluding burn-in and burn-out periods)
   purrr::map2_df(run_group$raw_meteo_fl, run_group$export_fl, function(raw_meteo_fl, export_file) {
@@ -25,8 +30,11 @@ combine_glm_output <- function(run_group, outfile_template) {
     meteo_data <- arrow::read_feather(raw_meteo_fl, col_select = "time")
     begin <- min(meteo_data$time)
     end <- max(meteo_data$time)
-    # read in data for that time period and truncate
+    # read in data for that time period, remove the ice
+    # thickness, evaporation, and n_layers variables, and truncate
+    # the predictions based on the defined begin and end dates
     arrow::read_feather(export_file) %>%
+      select(-hice, -evap, -n_layers) %>%
       filter(time >= as.Date(begin) & time <= as.Date(end))
   }) %>% arrow::write_feather(outfile)
   

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository is for running uncalibrated GLM models of lake temperatures.
 -----------------
 ## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep)
 _Files that will eventually be transferred using GLOBUS:_
-  * Lake - GCM cell crosswalk: `'1_prep/in/lake_cell_xwalk.csv'`
-    * Created within [`gcm_driver_data_munge_pipeline` branch](https://github.com/USGS-R/lake-temperature-model-prep/tree/gcm_driver_data_munge_pipeline) of repo
+  * Lake - GCM tile cell crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
+    * Created within [the `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R#L194-L213) of the repo
   * List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
   * Munged GCM netCDF files (not yet brought in manually, see below)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is for running uncalibrated GLM models of lake temperatures.
 -----------------
 ## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep)
 _Files that will eventually be transferred using GLOBUS:_
-  * Lake - GCM tile cell crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
+  * Lake - GCM cell tile crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
     * Created within [the `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R#L194-L213) of the repo
   * List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
   * Munged GCM netCDF files (not yet brought in manually, see below)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is for running uncalibrated GLM models of lake temperatures.
 ## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep)
 _Files that will eventually be transferred using GLOBUS:_
   * Lake - GCM cell tile crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
-    * Created within [the `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R#L194-L213) of the repo
+    * Created within [the `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R), look for the `lake_cell_tile_xwalk_df` target
   * List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
   * Munged GCM netCDF files (not yet brought in manually, see below)
 


### PR DESCRIPTION
In preparation for a future PR with diagnostic plots, modify the code that extracts and saves the raw GLM output to extract ice thickness, evaporation, and the number of layers for each timestep in addition to the temperature predictions and ice flags.

Downstream, when the GLM output is compiled for each lake-gcm combo (across all 3 time periods), only write the depth-specific temperature predictions and ice flag variables to the final feather files.