### PR TITLE
Docker umask fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,6 @@ RUN install2.r --error \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Fix umask problems with RStudio in singularity
-#RUN echo "server-set-umask=0" >> /etc/rstudio/rserver.conf
 RUN echo "Sys.umask(mode=002)" >> /usr/local/lib/R/etc/Rprofile.site
 
 # RStudio does not pick up the full environment from the singularity container!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN install2.r --error \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Fix umask problems with RStudio in singularity
-RUN echo "server-set-umask=0" >> /etc/rstudio/rserver.conf
+#RUN echo "server-set-umask=0" >> /etc/rstudio/rserver.conf
 RUN echo "Sys.umask(mode=002)" >> /usr/local/lib/R/etc/Rprofile.site
 
 # RStudio does not pick up the full environment from the singularity container!

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       context: .
     ports:
       - "8787:8787"
+    volumes:
+      - type: bind
+        source: ../
+        target: /code
     environment:
       - ROOT=TRUE
       - PASSWORD=mypass

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - type: bind
         source: ../
-        target: /code
+        target: /lakes
     environment:
       - ROOT=TRUE
       - PASSWORD=mypass


### PR DESCRIPTION
I copied some old code and introduced a regression, so that RStudio wasn't using a group-friendly umask. This led @hcorson-dosch to be unable to run the pipeline because she didn't have write permission on the files created in `_targets/` when I ran it.

This fixes that. To test it I downloaded the fixed image and ran the pipeline. All the files created in `_targets` are group-writable:

```bash
[jross@tg-login2 lake-temperature-process-models] find _targets/ ! -perm /g+w
[jross@tg-login2 lake-temperature-process-models]
```