### PR TITLE
adjust grouping

### DIFF
--- a/2_run.R
+++ b/2_run.R
@@ -29,8 +29,10 @@ p2 <- list(
     p2_glm_uncalibrated_runs %>%
       select(site_id, gcm, time_period, gcm_start_date, gcm_end_date, 
              export_fl, export_fl_hash, glm_success) %>%
-      group_by(site_id, gcm) %>% 
-      filter(all(glm_success)) %>%
+      group_by(site_id) %>% 
+      filter(all(glm_success)) %>% # Check that all 18 models (3 time periods * 6 GCMs) succeeded for each lake
+      ungroup() %>%
+      group_by(site_id, gcm) %>% # Group by site_id and gcm for creating export files
       tar_group(),
     iteration = "group"
   ),


### PR DESCRIPTION
Per convo w/ @lindsayplatt and her convo w/ Jordan based on #45 -- we're switching to only exporting output for lakes for which all 18 model runs (3 time periods * 6 GCMs) succeeded. This means grouping the model runs tibble by `site_id` to check if n=18 runs succeeded. Previously we were grouping by `site_id` and `gcm`, so that we were checking if n=3 model runs succeeded (3 time periods). That meant that we were exporting results by lake-gcm combo, and for some lakes we had results for all 6 GCMs, but for others we did not.

For now, we're still regrouping the filtered tibble (of runs associated with lakes w/ n=18 successful runs) by `site_id` and `gcm` to write the output to files, since that's the set-up that `lake-temperature-model-out` expects and it's not worth changing in light of the upcoming modifications to the workflow to store the results in netCDF format (#31)