### PR TITLE
Add nldas runs

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -1,8 +1,10 @@
-source('1_prep/src/munge_netCDFs.R')
+source('1_prep/src/munge_meteo.R')
 source('1_prep/src/build_model_config.R')
 source('1_prep/src/munge_nmls.R')
 
 p1 <- list(
+  # Pull in GLM 3 template
+  tar_target(p1_glm_template_nml, '1_prep/in/glm3_template.nml', format = 'file'),
   
   ##### Pull in files from lake-temperature-model-prep #####
   # TODO - transfer to Denali using globus
@@ -18,11 +20,11 @@ p1 <- list(
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
                filter(site_id %in% p1_nml_site_ids) %>%
                arrange(site_id) %>% #),
-               filter(site_id %in% c('nhdhr_105567868','nhdhr_105569506', 'nhdhr_105569520', 'nhdhr_114336097', 'nhdhr_120019185','nhdhr_114544667'))),
+               filter(site_id %in% c('nhdhr_105567868', 'nhdhr_105569506', 'nhdhr_105569520', 'nhdhr_114336097', 'nhdhr_120019185','nhdhr_114544667'))), #   
   # Pull vector of site ids
   tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
   # Subset nml list
-  tar_target(p1_nml_list, readr::read_rds(p1_nml_list_rds)[p1_site_ids]),
+  tar_target(p1_nml_list_subset, readr::read_rds(p1_nml_list_rds)[p1_site_ids]),
   
   ##### GCM model set up #####
   # Define mapping variables
@@ -39,72 +41,61 @@ p1 <- list(
              pattern = map(p1_gcm_names)),
 
   # Pull vectors data cell numbers
-  tar_target(p1_cell_nos, unique(p1_lake_cell_tile_xwalk_df %>% pull(data_cell_no))),
+  tar_target(p1_gcm_cell_nos, unique(p1_lake_cell_tile_xwalk_df %>% pull(data_cell_no))),
 
   # Specify length of desired burn-in and burn-out periods, in days
-  tar_target(p1_burn_in, 300),
-  tar_target(p1_burn_out, 190),
+  tar_target(p1_gcm_burn_in, 300),
+  tar_target(p1_gcm_burn_out, 190),
   # Pull out start and end dates of raw meteo data
   # and note start of burn-in and end of burn-out
   tar_target(p1_gcm_dates,
              munge_gcm_dates(p1_gcm_ncs,
                              p1_gcm_time_periods,
-                             burn_in = p1_burn_in,
-                             burn_out = p1_burn_out)),
+                             burn_in = p1_gcm_burn_in,
+                             burn_out = p1_gcm_burn_out)),
   # Generate GCM/time-period/cell-specific csv files
-  tar_target(p1_meteo_csvs,
-             munge_nc_files(p1_gcm_ncs, 
+  tar_target(p1_gcm_csvs,
+             munge_gcm_nc_files(p1_gcm_ncs, 
                             p1_gcm_names, 
-                            p1_cell_nos,
+                            p1_gcm_cell_nos,
                             p1_gcm_dates,
                             outfile_template = '1_prep/out/GCM_%s_%s_%s.csv'),
              format = 'file',
              pattern = map(p1_gcm_ncs, p1_gcm_names)),
 
   # build model config
-  tar_target(p1_model_config,
-             build_model_config(p1_meteo_csvs, p1_lake_cell_tile_xwalk_df, p1_gcm_names, p1_gcm_dates)),
+  tar_target(p1_gcm_model_config,
+             build_gcm_model_config(p1_gcm_csvs, p1_lake_cell_tile_xwalk_df, p1_gcm_names, p1_gcm_dates)),
   
   # Set up list of nml objects, with NULL for meteo_fl, and custom depth parameters
   # Transform a single file of all lakes to a single list of all lakes
   # (subset to p1_site_ids), then tell `targets` to think of that list as an iterable list
-  tar_target(p1_glm_template_nml, '1_prep/in/glm3_template.nml', format = 'file'),
-  tar_target(p1_nml_objects,
-             munge_nmls(nml_list_rds = p1_nml_list_rds, # could pass p1_nml_list instead
-                        site_ids = p1_site_ids, # and then wouldn't need to pass site_ids
-                        base_nml = p1_glm_template_nml),
+  
+  tar_target(p1_gcm_nml_objects,
+             munge_model_nmls(nml_list = p1_nml_list_subset,
+                        base_nml = p1_glm_template_nml,
+                        driver_type = 'gcm'),
              packages = c('glmtools'),
              iteration = 'list'),
   
   ##### NLDAS model set up #####
   tar_target(p1_nldas_time_period, c('1980_2021')),
-  # # track unique NLDAS files
-  # # length(p1_nldas_csvs) = # of unique NLDAS files associated with p1_site_ids
-  # tar_target(p1_nldas_csvs,
-  #            {
-  #              nldas_files <- c()
-  #              for (site_id in p1_site_ids) {
-  #                site_nml <- p1_nml_list[[site_id]]
-  #                site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
-  #                if (!(site_nldas_file %in% nldas_files)) {
-  #                  nldas_files <- c(nldas_files, site_nldas_file)
-  #                }
-  #              }
-  #              return(nldas_files)
-  #            },
-  #            format = 'file'
-  # ),
-  # track NLDAS files for each site
-  # length(p1_nldas_csvs) = length(site_ids)
+  # track unique NLDAS files
+  # length(p1_nldas_csvs) = # of unique NLDAS files associated with p1_site_ids
   tar_target(p1_nldas_csvs,
              {
-               site_nml <- p1_nml_list[[p1_site_ids]]
-               site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
-               return(site_nldas_file)
+               nldas_files <- c()
+               for (site_id in p1_site_ids) {
+                 site_nml <- p1_nml_list_subset[[site_id]]
+                 site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
+                 if (!(site_nldas_file %in% nldas_files)) {
+                   nldas_files <- c(nldas_files, site_nldas_file)
+                 }
+               }
+               return(nldas_files)
              },
-             format = 'file',
-             pattern = map(p1_site_ids)
-             ),
+             format = 'file'
+  ),
   
   # Define model start and end dates and note start of
   # burn-in and end of burn-out based on extent of NLDAS data
@@ -113,19 +104,20 @@ p1 <- list(
   tar_target(
     p1_nldas_dates,
     munge_nldas_dates(p1_nldas_csvs, p1_nldas_time_period)),
-  
-  # Set up NLDAS model config
-  tar_target(p1_nldas_model_config,
-             build_nldas_model_config(p1_site_ids, p1_nldas_csvs, p1_nldas_dates),
-             pattern = map(p1_site_ids, p1_nldas_csvs)
-  ),
+
   
   # Set up nmls for NLDAS model runs
   tar_target(p1_nldas_nml_objects,
-             munge_model_nmls(nml_list = p1_nml_list,
+             munge_model_nmls(nml_list = p1_nml_list_subset,
                               base_nml = p1_glm_template_nml,
                               driver_type = 'nldas'),
              packages = c('glmtools'),
-             iteration = 'list')
+             iteration = 'list'),
+  
+  
+  # Set up NLDAS model config
+  tar_target(p1_nldas_model_config,
+             build_nldas_model_config(p1_site_ids, p1_nldas_nml_objects, p1_nldas_csvs, p1_nldas_dates)
+  )
 )
 

--- a/1_prep.R
+++ b/1_prep.R
@@ -105,6 +105,10 @@ p1 <- list(
     p1_nldas_dates,
     munge_nldas_dates(p1_nldas_csvs, p1_nldas_time_period)),
 
+  # Set up NLDAS model config
+  tar_target(p1_nldas_model_config,
+             build_nldas_model_config(p1_site_ids, p1_nml_list_subset, p1_nldas_csvs, p1_nldas_dates)
+  ),
   
   # Set up nmls for NLDAS model runs
   tar_target(p1_nldas_nml_objects,
@@ -112,12 +116,6 @@ p1 <- list(
                               base_nml = p1_glm_template_nml,
                               driver_type = 'nldas'),
              packages = c('glmtools'),
-             iteration = 'list'),
-  
-  
-  # Set up NLDAS model config
-  tar_target(p1_nldas_model_config,
-             build_nldas_model_config(p1_site_ids, p1_nldas_nml_objects, p1_nldas_csvs, p1_nldas_dates)
-  )
+             iteration = 'list')
 )
 

--- a/1_prep.R
+++ b/1_prep.R
@@ -3,11 +3,8 @@ source('1_prep/src/build_model_config.R')
 source('1_prep/src/munge_nmls.R')
 
 p1 <- list(
-  # Define mapping variables
-  tar_target(p1_gcm_names, c('ACCESS', 'GFDL', 'CNRM', 'IPSL', 'MRI', 'MIROC5')),
-  tar_target(p1_gcm_time_periods, c('1981_2000', '2040_2059', '2080_2099')),
   
-  ### Pull in files from lake-temperature-model-prep
+  ##### Pull in files from lake-temperature-model-prep #####
   # TODO - transfer to Denali using globus
   # list of lake-specific attributes for nml modification
   # file copied from lake-temperature-model-prep repo
@@ -20,7 +17,17 @@ p1 <- list(
   tar_target(p1_lake_cell_tile_xwalk_df, 
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
                filter(site_id %in% p1_nml_site_ids) %>%
-               arrange(site_id)),
+               arrange(site_id) %>% #),
+               filter(site_id %in% c('nhdhr_105567868','nhdhr_105569506', 'nhdhr_105569520', 'nhdhr_114336097', 'nhdhr_120019185','nhdhr_114544667'))),
+  # Pull vector of site ids
+  tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
+  # Subset nml list
+  tar_target(p1_nml_list, readr::read_rds(p1_nml_list_rds)[p1_site_ids]),
+  
+  ##### GCM model set up #####
+  # Define mapping variables
+  tar_target(p1_gcm_names, c('ACCESS', 'GFDL', 'CNRM', 'IPSL', 'MRI', 'MIROC5')),
+  tar_target(p1_gcm_time_periods, c('1981_2000', '2040_2059', '2080_2099')),
   # NetCDF files with munged GCM driver data (one per GCM)
   # files copied from lake-temperature-model-prep repo
   tar_target(p1_gcm_ncs, 
@@ -31,8 +38,7 @@ p1 <- list(
              format = 'file',
              pattern = map(p1_gcm_names)),
 
-  # Pull vectors of site ids and data cell numbers
-  tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
+  # Pull vectors data cell numbers
   tar_target(p1_cell_nos, unique(p1_lake_cell_tile_xwalk_df %>% pull(data_cell_no))),
 
   # Specify length of desired burn-in and burn-out periods, in days
@@ -64,9 +70,61 @@ p1 <- list(
   # (subset to p1_site_ids), then tell `targets` to think of that list as an iterable list
   tar_target(p1_glm_template_nml, '1_prep/in/glm3_template.nml', format = 'file'),
   tar_target(p1_nml_objects,
-             munge_nmls(nml_list_rds = p1_nml_list_rds,
-                        site_ids = p1_site_ids,
+             munge_nmls(nml_list_rds = p1_nml_list_rds, # could pass p1_nml_list instead
+                        site_ids = p1_site_ids, # and then wouldn't need to pass site_ids
                         base_nml = p1_glm_template_nml),
+             packages = c('glmtools'),
+             iteration = 'list'),
+  
+  ##### NLDAS model set up #####
+  tar_target(p1_nldas_time_period, c('1980_2021')),
+  # # track unique NLDAS files
+  # # length(p1_nldas_csvs) = # of unique NLDAS files associated with p1_site_ids
+  # tar_target(p1_nldas_csvs,
+  #            {
+  #              nldas_files <- c()
+  #              for (site_id in p1_site_ids) {
+  #                site_nml <- p1_nml_list[[site_id]]
+  #                site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
+  #                if (!(site_nldas_file %in% nldas_files)) {
+  #                  nldas_files <- c(nldas_files, site_nldas_file)
+  #                }
+  #              }
+  #              return(nldas_files)
+  #            },
+  #            format = 'file'
+  # ),
+  # track NLDAS files for each site
+  # length(p1_nldas_csvs) = length(site_ids)
+  tar_target(p1_nldas_csvs,
+             {
+               site_nml <- p1_nml_list[[p1_site_ids]]
+               site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
+               return(site_nldas_file)
+             },
+             format = 'file',
+             pattern = map(p1_site_ids)
+             ),
+  
+  # Define model start and end dates and note start of
+  # burn-in and end of burn-out based on extent of NLDAS data
+  # (using 1/2/1979 - 12/31/1979 for burn-in, and 1/1/2021 - 
+  # 4/11/2021 for burn-out)
+  tar_target(
+    p1_nldas_dates,
+    munge_nldas_dates(p1_nldas_csvs, p1_nldas_time_period)),
+  
+  # Set up NLDAS model config
+  tar_target(p1_nldas_model_config,
+             build_nldas_model_config(p1_site_ids, p1_nldas_csvs, p1_nldas_dates),
+             pattern = map(p1_site_ids, p1_nldas_csvs)
+  ),
+  
+  # Set up nmls for NLDAS model runs
+  tar_target(p1_nldas_nml_objects,
+             munge_model_nmls(nml_list = p1_nml_list,
+                              base_nml = p1_glm_template_nml,
+                              driver_type = 'nldas'),
              packages = c('glmtools'),
              iteration = 'list')
 )

--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -1,9 +1,9 @@
 #' @title build a lake-gcm-time-period crosswalk table that serves as the model config
 #' @description Build a dplyr table with tar_grouping that has one row per
-#' Lake-GCM-time-period combination and columns for the (1) tar branch name 
+#' Lake-GCM-time-period combination and columns for the (1) file name 
 #' and (2) data hash for the meteo data for each combo. We can use this to run models.
 #' For the string extraction to work, data_cell_no must be at the END of the meteo filename
-#' @param meteo_csvs - names of the gcm/time-period/cell specific csv files
+#' @param gcm_csvs - names of the gcm/time-period/cell specific csv files
 #' @param lake_cell_tile_xwalk - mapping of which lakes fall into which gcm cells and tiles
 #' (parameters `spatial_cell_no` and `spatial_tile_no`) and which gcm cell to use for driver 
 #' data for each lake (`data_cell_no`,`data_tile_no`). `data_cell_no` will only differ from
@@ -14,18 +14,18 @@
 #' burn in, the burn-in start date, the length of burn-out, and the burn-out
 #' end date for each time period
 #' @return a dplyr tibble with one row per model run, with columns for site_id, state,
-#' gcm, time_period, gcm_start_date, gcm_end_date, burn_in, burn_in_start, burn_out, burn_out_end,
-#' meteo_fl, and meteo_fl_hash
-build_model_config <- function(meteo_csvs, lake_cell_tile_xwalk, gcm_names, gcm_dates){
+#' driver (name of gcm), time_period, driver_start_date, driver_end_date, burn_in, 
+#' burn_in_start, burn_out, burn_out_end, meteo_fl, and meteo_fl_hash
+build_gcm_model_config <- function(gcm_csvs, lake_cell_tile_xwalk, gcm_names, gcm_dates){
   # collapse the gcm_names, gcm_date, and cell_no vectors for use in string matching
   gcm_name_list <- paste(gcm_names,collapse="|")
   gcm_time_period_list <- paste(gcm_dates$time_period,collapse="|")
   data_cell_no_list <- paste(unique(lake_cell_tile_xwalk$data_cell_no),collapse= "|")
   # Build tibble of meteo files, branches, hashes, gcm name, cell_no, and time_period
   meteo_branches <- tibble(
-    meteo_fl = meteo_csvs,
-    meteo_fl_hash = tools::md5sum(meteo_csvs),
-    gcm = stringr::str_extract(meteo_fl, gcm_name_list),
+    meteo_fl = gcm_csvs,
+    meteo_fl_hash = tools::md5sum(gcm_csvs),
+    driver = stringr::str_extract(meteo_fl, gcm_name_list),
     time_period = stringr::str_extract(meteo_fl, gcm_time_period_list),
     # cell_no is the very last part of the file name and so this str_extract() is 
     # set up to use a regex that looks for a match in the last part of the filename 
@@ -41,61 +41,51 @@ build_model_config <- function(meteo_csvs, lake_cell_tile_xwalk, gcm_names, gcm_
   # captured by the `meteo_fl_hash` column
   model_config <- tidyr::expand_grid(
     nesting(select(lake_cell_tile_xwalk, site_id, state, data_cell_no)),
-    gcm = gcm_names, 
+    driver = gcm_names, 
     nesting(gcm_dates)) %>%
     arrange(site_id) %>%
-    left_join(meteo_branches, by=c('gcm', 'data_cell_no', 'time_period')) %>%
+    left_join(meteo_branches, by=c('driver', 'data_cell_no', 'time_period')) %>%
     select(-data_cell_no) %>%
     rowwise()
   return(model_config)
 }
 
-build_nldas_model_config <- function(site_id, nldas_csv, nldas_dates) {
-  model_config <- tibble(
-    site_id = site_id, 
-    gcm = 'nldas', #using column name 'gcm' for testing - then will be 'driver_type'
-    meteo_fl = nldas_csv,
-    meteo_fl_hash = tools::md5sum(nldas_csv)
-  ) %>%
-    cbind(nldas_dates) %>%
-    # for now, use column names 'gcm_start_date' and 'gcm_end_date' for testing, - then will be 'driver_start_date'
-    select(site_id, gcm, time_period, gcm_start_date=driver_start_date, gcm_end_date=driver_end_date, 
-           burn_in, burn_in_start, burn_out, burn_out_end, meteo_fl, meteo_fl_hash) #select(site_id, gcm, colnames(nldas_dates), meteo_fl, meteo_fl_hash)
-
-  return(model_config)
-}
-
-#' @title Munge NLDAS dates
-#' @description Function to determine the start and end dates of the
-#' NLDAS time period and document the date when burn-in starts and the date
-#' when burn-out ends, based on the dates of the raw NLDAS meteorological data.
-#' @param nldas_csvs filepaths of the NLDAS csv files
-#' @param nldas_time_period - the user-set NLDAS time period, defined by its 
-#' bracketing years
-#' @return a tibble with a row for each time period, and columns specifying
-#' the start and end date of each time period, as well as the length of
+#' @title build a model configuration table for the NDLAS runs
+#' @description Build a dplyr table with tar_grouping that has one row per
+#' lake and columns for the (1) file name and (2) data hash for the meteo data for each 
+#' lake. We can use this to run models.
+#' @param site_ids - The vector of site_ids (p1_site_ids)
+#' @param nml_list - nested list of lake-specific nml parameters
+#' @param nldas_csvs - The unique nldas files (p1_nldas_csvs)
+#' @param nldas_dates - a tibble with a row for the 1980-2021 NLDAS time period, and 
+#' columns specifying the start and end date of the time period, as well as the length of
 #' burn in, the burn-in start date, the length of burn-out, and the burn-out
 #' end date for each time period
-munge_nldas_dates <- function(nldas_csvs, nldas_time_period) {
-  model_years <- strsplit(nldas_time_period,'_')[[1]]
+#' @return a dplyr tibble with nrows = length(p1_site_ids) with columns for site_id, 
+#' driver ('NLDAS'), time_period, driver_start_date, driver_end_date, burn_in, burn_in_start, 
+#' burn_out, burn_out_end, meteo_fl, and meteo_fl_hash
+build_nldas_model_config <- function(site_ids, nml_list, nldas_csvs, nldas_dates) {
+  meteo_branches <- tibble(
+    meteo_fl = nldas_csvs,
+    basename_meteo_fl = basename(meteo_fl),
+    meteo_fl_hash = tools::md5sum(nldas_csvs)
+  )
+  site_meteo_xwalk <- purrr::map_df(site_ids, function(site_id) {
+    site_nml_list <- nml_list[[site_id]]
+    site_meteo_xwalk <- tibble(
+      site_id = site_id,
+      basename_meteo_fl = site_nml_list$meteo_fl
+    )
+    return(site_meteo_xwalk)
+  })
+  model_config <- tidyr::expand_grid(
+    nesting(site_meteo_xwalk),
+    driver = 'NLDAS', 
+    nesting(nldas_dates)) %>%
+    arrange(site_id) %>%
+    left_join(meteo_branches, by=c('basename_meteo_fl')) %>%
+    select(-basename_meteo_fl) %>%
+    rowwise()
   
-  # Use first csv file, since all have the same date range
-  nldas_meteo <- readr::read_csv(nldas_csvs[1], col_types= cols())
-  
-  nldas_dates <- tibble(
-    time = lubridate::as_date(nldas_meteo$time),
-    time_period = nldas_time_period
-    ) %>%
-    group_by(time_period) %>%
-    # set burn-in start and burn-out end based on extend of NLDAS data
-    summarize(burn_in_start = min(time), burn_out_end = max(time)) %>%
-    mutate(
-      driver_start_date = as.Date(sprintf('%s-01-01', model_years[1])), # set based on user-defined modeling period
-      driver_end_date = as.Date(sprintf('%s-12-31', model_years[2])), # set based on user-defined modeling period
-      # the burn-in period is the period that precedes the first full year of the NLDAS time period
-      burn_in = driver_start_date - burn_in_start,
-      # the burn-out period is the period that follows the final full year of the NLDAS time period
-      burn_out = burn_out_end - driver_end_date)
-  
-  return(nldas_dates)
+  return(model_config)
 }

--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -49,3 +49,53 @@ build_model_config <- function(meteo_csvs, lake_cell_tile_xwalk, gcm_names, gcm_
     rowwise()
   return(model_config)
 }
+
+build_nldas_model_config <- function(site_id, nldas_csv, nldas_dates) {
+  model_config <- tibble(
+    site_id = site_id, 
+    gcm = 'nldas', #using column name 'gcm' for testing - then will be 'driver_type'
+    meteo_fl = nldas_csv,
+    meteo_fl_hash = tools::md5sum(nldas_csv)
+  ) %>%
+    cbind(nldas_dates) %>%
+    # for now, use column names 'gcm_start_date' and 'gcm_end_date' for testing, - then will be 'driver_start_date'
+    select(site_id, gcm, time_period, gcm_start_date=driver_start_date, gcm_end_date=driver_end_date, 
+           burn_in, burn_in_start, burn_out, burn_out_end, meteo_fl, meteo_fl_hash) #select(site_id, gcm, colnames(nldas_dates), meteo_fl, meteo_fl_hash)
+
+  return(model_config)
+}
+
+#' @title Munge NLDAS dates
+#' @description Function to determine the start and end dates of the
+#' NLDAS time period and document the date when burn-in starts and the date
+#' when burn-out ends, based on the dates of the raw NLDAS meteorological data.
+#' @param nldas_csvs filepaths of the NLDAS csv files
+#' @param nldas_time_period - the user-set NLDAS time period, defined by its 
+#' bracketing years
+#' @return a tibble with a row for each time period, and columns specifying
+#' the start and end date of each time period, as well as the length of
+#' burn in, the burn-in start date, the length of burn-out, and the burn-out
+#' end date for each time period
+munge_nldas_dates <- function(nldas_csvs, nldas_time_period) {
+  model_years <- strsplit(nldas_time_period,'_')[[1]]
+  
+  # Use first csv file, since all have the same date range
+  nldas_meteo <- readr::read_csv(nldas_csvs[1], col_types= cols())
+  
+  nldas_dates <- tibble(
+    time = lubridate::as_date(nldas_meteo$time),
+    time_period = nldas_time_period
+    ) %>%
+    group_by(time_period) %>%
+    # set burn-in start and burn-out end based on extend of NLDAS data
+    summarize(burn_in_start = min(time), burn_out_end = max(time)) %>%
+    mutate(
+      driver_start_date = as.Date(sprintf('%s-01-01', model_years[1])), # set based on user-defined modeling period
+      driver_end_date = as.Date(sprintf('%s-12-31', model_years[2])), # set based on user-defined modeling period
+      # the burn-in period is the period that precedes the first full year of the NLDAS time period
+      burn_in = driver_start_date - burn_in_start,
+      # the burn-out period is the period that follows the final full year of the NLDAS time period
+      burn_out = burn_out_end - driver_end_date)
+  
+  return(nldas_dates)
+}

--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -21,33 +21,6 @@ adjust_depth_args_nml <- function(nml_args) {
   return(nml_edits)
 }
 
-#' @Title Munge default nml lists
-#' @decription Replace the NLDAS filename stored as 'meteo_fl'
-#' with 'NULL', remove used nml parameter 'site_id'
-#' @param nml_list_rds rds file of lake-specific nml parameters
-#' @param site_ids vector of lakes from lake_cell_tile_xwalk
-#' @param base_nml glm3 nml template
-#' @return complete nml objects
-munge_nmls <- function(nml_list_rds, site_ids, base_nml) {
-  nml_list <- readr::read_rds(nml_list_rds)[site_ids]
-  nml_template <- read_nml(base_nml)
-  # create the munged nml objects
-  nml_objs <- purrr::map(nml_list, function(nml) {
-      # make edits to nml depth-related parameters
-      nml <- purrr::list_modify(nml, !!!adjust_depth_args_nml(nml))
-      # set meteo_fl value to NULL
-      nml <- purrr::list_modify(nml, !!!c('meteo_fl' = 'NULL'))
-      # disable evaporation
-      nml <- purrr::list_modify(nml, !!!c('disable_evap' = TRUE))
-      # remove helpful but non-nml values
-      nml <- nml[!(names(nml) %in% c('site_id'))]
-      # merge into base nml, checking arguments along the way
-      nml_obj <- set_nml(nml_template, arg_list = nml)
-    })
-  
-  return(nml_objs)
-}
-
 #' @Title Munge default nml lists for NLDAS runs
 #' @decription Customize glm3 template nml using the values
 #' in p1_nml_list, remove used nml parameter 'site_id'

--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -21,7 +21,7 @@ adjust_depth_args_nml <- function(nml_args) {
   return(nml_edits)
 }
 
-#' @Title Munge default nml lists for NLDAS runs
+#' @Title Munge default nml lists for NLDAS & GCM runs
 #' @decription Customize glm3 template nml using the values
 #' in p1_nml_list, remove used nml parameter 'site_id'
 #' @param nml_list nested list of lake-specific nml parameters
@@ -36,7 +36,7 @@ munge_model_nmls <- function(nml_list, base_nml, driver_type) {
     # make edits to nml depth-related parameters
     nml <- purrr::list_modify(nml, !!!adjust_depth_args_nml(nml))
     # If the nml will note be used for a NLDAS-driven model run
-    if (!(driver_type=='nldas')) {
+    if (driver_type!='nldas') {
       # set meteo_fl value to NULL
       nml <- purrr::list_modify(nml, !!!c('meteo_fl' = 'NULL'))
     }

--- a/1_prep/src/munge_nmls.R
+++ b/1_prep/src/munge_nmls.R
@@ -47,3 +47,33 @@ munge_nmls <- function(nml_list_rds, site_ids, base_nml) {
   
   return(nml_objs)
 }
+
+#' @Title Munge default nml lists for NLDAS runs
+#' @decription Customize glm3 template nml using the values
+#' in p1_nml_list, remove used nml parameter 'site_id'
+#' @param nml_list nested list of lake-specific nml parameters
+#' @param base_nml glm3 nml template
+#' @param driver_type 'gcm' or 'nldas'. If 'gcm', the meteo_fl
+#' file name in the `nml_list` (specific to NLDAS) is overwritten
+#' @return complete nml objects
+munge_model_nmls <- function(nml_list, base_nml, driver_type) {
+  nml_template <- read_nml(base_nml)
+  # create the munged nml objects
+  nml_objs <- purrr::map(nml_list, function(nml) {
+    # make edits to nml depth-related parameters
+    nml <- purrr::list_modify(nml, !!!adjust_depth_args_nml(nml))
+    # If the nml will note be used for a NLDAS-driven model run
+    if (!(driver_type=='nldas')) {
+      # set meteo_fl value to NULL
+      nml <- purrr::list_modify(nml, !!!c('meteo_fl' = 'NULL'))
+    }
+    # disable evaporation
+    nml <- purrr::list_modify(nml, !!!c('disable_evap' = TRUE))
+    # remove helpful but non-nml values
+    nml <- nml[!(names(nml) %in% c('site_id'))]
+    # merge into base nml, checking arguments along the way
+    nml_obj <- set_nml(nml_template, arg_list = nml)
+  })
+  
+  return(nml_objs)
+}

--- a/2_run.R
+++ b/2_run.R
@@ -7,34 +7,34 @@ p2 <- list(
   # but return a tibble that includes that filename and its hash
   # put simulation directories in sub-directory for easy deletion
   tar_target(
-    p2_glm_uncalibrated_runs,
+    p2_gcm_glm_uncalibrated_runs,
     {
       # check mapping to ensure is correct
-      tar_assert_identical(p1_model_config$site_id, p1_nml_objects$morphometry$lake_name, "p1_nml_object site id doesn't match p1_model_config site id")
+      tar_assert_identical(p1_gcm_model_config$site_id, p1_gcm_nml_objects$morphometry$lake_name, "p1_nml_object site id doesn't match p1_gcm_model_config site id")
       run_glm3_model(
         sim_dir = '2_run/tmp/simulations',
-        nml_obj = p1_nml_objects,
-        model_config = p1_model_config,
+        nml_obj = p1_gcm_nml_objects,
+        model_config = p1_gcm_model_config,
         export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather')
     },
     packages = c('retry','glmtools', 'GLM3r'),
-    pattern = map(p1_model_config, cross(p1_nml_objects, p1_gcm_names, p1_gcm_dates))),
+    pattern = map(p1_gcm_model_config, cross(p1_gcm_nml_objects, p1_gcm_names, p1_gcm_dates))),
   
   # For bundling of results by lake and by GCM in 3_extract
-  # Group model runs by lake id and gcm
+  # Group model runs by lake id and driver
   # Discard the glm diagnostics so they don't trigger rebuilds
   # even when the export_fl_hash is unchanged
   # Filter to groups where all model runs were successful 
   # (if any failed, the group is filtered out)
   tar_target(
-    p2_glm_uncalibrated_run_groups,
-    p2_glm_uncalibrated_runs %>%
-      select(site_id, gcm, time_period, gcm_start_date, gcm_end_date, 
+    p2_gcm_glm_uncalibrated_run_groups,
+    p2_gcm_glm_uncalibrated_runs %>%
+      select(site_id, driver, time_period, driver_start_date, driver_end_date, 
              export_fl, export_fl_hash, glm_success) %>%
       group_by(site_id) %>% 
       filter(all(glm_success)) %>% # Check that all 18 models (3 time periods * 6 GCMs) succeeded for each lake
       ungroup() %>%
-      group_by(site_id, gcm) %>% # Group by site_id and gcm for creating export files
+      group_by(site_id, driver) %>% # Group by site_id and driver (GCM) for creating export files
       tar_group(),
     iteration = "group"
   ),
@@ -46,9 +46,9 @@ p2 <- list(
   # Filter to groups where all model runs were successful 
   # (if any failed, the group is filtered out)
   tar_target(
-    p2_glm_uncalibrated_lake_groups,
-    p2_glm_uncalibrated_runs %>%
-      select(site_id, gcm, time_period, gcm_start_date, gcm_end_date, 
+    p2_gcm_glm_uncalibrated_lake_groups,
+    p2_gcm_glm_uncalibrated_runs %>%
+      select(site_id, driver, time_period, driver_start_date, driver_end_date, 
              export_fl, export_fl_hash, glm_success) %>%
       group_by(site_id) %>% 
       filter(all(glm_success)) %>%
@@ -82,7 +82,7 @@ p2 <- list(
   tar_target(
     p2_nldas_glm_uncalibrated_run_groups,
     p2_nldas_glm_uncalibrated_runs %>%
-      select(site_id, gcm, time_period, gcm_start_date, gcm_end_date, 
+      select(site_id, driver, time_period, driver_start_date, driver_end_date, 
              export_fl, export_fl_hash, glm_success) %>% 
       filter(glm_success==TRUE) %>%
       group_by(site_id) %>% # Group by site_id for creating export files

--- a/2_run.R
+++ b/2_run.R
@@ -84,7 +84,7 @@ p2 <- list(
     p2_nldas_glm_uncalibrated_runs %>%
       select(site_id, driver, time_period, driver_start_date, driver_end_date, 
              export_fl, export_fl_hash, glm_success) %>% 
-      filter(glm_success==TRUE) %>%
+      filter(glm_success) %>%
       group_by(site_id) %>% # Group by site_id for creating export files
       tar_group(),
     iteration = "group"

--- a/2_run.R
+++ b/2_run.R
@@ -1,6 +1,8 @@
 source('2_run/src/run_glm3.R')
 
 p2 <- list(
+  
+  ##### GCM model runs #####
   # Function will generate file
   # but return a tibble that includes that filename and its hash
   # put simulation directories in sub-directory for easy deletion
@@ -50,6 +52,40 @@ p2 <- list(
              export_fl, export_fl_hash, glm_success) %>%
       group_by(site_id) %>% 
       filter(all(glm_success)) %>%
+      tar_group(),
+    iteration = "group"
+  ),
+  
+  ##### NLDAS model runs #####
+  # Function will generate file
+  # but return a tibble that includes that filename and its hash
+  # put simulation directories in sub-directory for easy deletion
+  tar_target(
+    p2_nldas_glm_uncalibrated_runs,
+    {
+      # check mapping to ensure is correct
+      tar_assert_identical(p1_nldas_model_config$site_id, p1_nldas_nml_objects$morphometry$lake_name, "p1_nldas_nml_objects site id doesn't match p1_nldas_model_config site id")
+      run_glm3_model(
+        sim_dir = '2_run/tmp/nldas_simulations',
+        nml_obj = p1_nldas_nml_objects,
+        model_config = p1_nldas_model_config,
+        export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather')
+    },
+    packages = c('retry','glmtools', 'GLM3r'),
+    pattern = map(p1_nldas_model_config, p1_nldas_nml_objects)),
+  
+  # For bundling of results by lake in 3_extract
+  # Group model runs by lake id
+  # Discard the glm diagnostics so they don't trigger rebuilds
+  # even when the export_fl_hash is unchanged
+  # Filter to successful model runs
+  tar_target(
+    p2_nldas_glm_uncalibrated_run_groups,
+    p2_nldas_glm_uncalibrated_runs %>%
+      select(site_id, gcm, time_period, gcm_start_date, gcm_end_date, 
+             export_fl, export_fl_hash, glm_success) %>% 
+      filter(glm_success==TRUE) %>%
+      group_by(site_id) %>% # Group by site_id for creating export files
       tar_group(),
     iteration = "group"
   )

--- a/3_extract.R
+++ b/3_extract.R
@@ -2,32 +2,32 @@ source('3_extract/src/process_glm_output.R')
 
 p3 <- list(
   ##### Extract GCM model output #####
-  # Use grouped target to combine glm output into feather files
+  # Use grouped runs target to combine GCM glm output into feather files
   # Function will generate the output feather file for each lake-gcm combo
   # across all three time periods, truncating the output to the valid dates 
-  # for each time period (exluding the burn-in and burn-out periods) and
+  # for each time period (excluding the burn-in and burn-out periods) and
   # saving only the temperature predictions for each depth and ice flags
   tar_target(
-    p3_glm_uncalibrated_output_feathers,
-    combine_glm_output(p2_glm_uncalibrated_run_groups, 
-                       outfile_template='3_extract/out/GLM_%s_%s.feather'),
+    p3_gcm_glm_uncalibrated_output_feathers,
+    write_glm_output(p2_gcm_glm_uncalibrated_run_groups,
+                     outfile_template='3_extract/out/GLM_%s_%s.feather'),
     format = 'file',
-    pattern = map(p2_glm_uncalibrated_run_groups)),
+    pattern = map(p2_gcm_glm_uncalibrated_run_groups)),
   
   # Generate a tibble with a row for each output file
   # that includes the filename and its hash along with the
-  # site_id, gcm, the state the lake is in, and the cell_no 
-  # and tile_no for that lake.
+  # site_id, driver (gcm name), the state the lake is in,  
+  # and the cell_no and tile_no for that lake.
   tar_target(
-    p3_glm_uncalibrated_output_feather_tibble,
-    generate_output_tibble(p2_glm_uncalibrated_run_groups, p3_glm_uncalibrated_output_feathers, p1_lake_cell_tile_xwalk_df),
-    pattern = map(p2_glm_uncalibrated_run_groups, p3_glm_uncalibrated_output_feathers)
+    p3_gcm_glm_uncalibrated_output_feather_tibble,
+    generate_output_tibble(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers, p1_lake_cell_tile_xwalk_df),
+    pattern = map(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers)
   ),
   
   # Group output feather tibble by spatial tile number
   tar_target(
-    p3_glm_uncalibrated_output_feather_groups,
-    p3_glm_uncalibrated_output_feather_tibble %>%
+    p3_gcm_glm_uncalibrated_output_feather_groups,
+    p3_gcm_glm_uncalibrated_output_feather_tibble %>%
       group_by(spatial_tile_no) %>%
       tar_group(),
     iteration = "group"
@@ -35,13 +35,33 @@ p3 <- list(
   
   # Generate a zip file for each tile, zipping the grouped feathers
   tar_target(
-    p3_glm_uncalibrated_output_zips,
-    zip_output_files(p3_glm_uncalibrated_output_feather_groups,
-                     zipfile_template= '3_extract/out/GLM_tile%s.zip'),
+    p3_gcm_glm_uncalibrated_output_zips,
+    {
+      files_to_zip <- p3_gcm_glm_uncalibrated_output_feather_groups$export_fl
+      zipfile_out <- sprintf('3_extract/out/GLM_GCMs_tile%s.zip', unique(p3_gcm_glm_uncalibrated_output_feather_groups$spatial_tile_no))
+      zip_output_files(files_to_zip, zipfile_out)
+    },
     format = 'file',
-    pattern = map(p3_glm_uncalibrated_output_feather_groups)
-  )
+    pattern = map(p3_gcm_glm_uncalibrated_output_feather_groups)
+  ),
   
   ##### Extract NLDAS model output #####
+  # Use grouped runs target to write NLDAS glm output to feather files
+  # Function will generate the output feather file for each lake, 
+  # truncating the output to the valid dates for the NLDAS time period 
+  # (excluding the burn-in and burn-out periods) and saving only the 
+  # temperature predictions for each depth and ice flags
+  tar_target(
+    p3_nldas_glm_uncalibrated_output_feathers,
+    write_glm_output(p2_nldas_glm_uncalibrated_run_groups,
+                     outfile_template='3_extract/out/GLM_%s_%s.feather'),
+    pattern = map(p2_nldas_glm_uncalibrated_run_groups)
+  ),
   
+  # Zip all NLDAS output into a single zip file
+  tar_target(
+    p3_nldas_glm_uncalibrated_output_zips,
+    zip_output_files(p3_nldas_glm_uncalibrated_output_feathers, '3_extract/out/GLM_NLDAS.zip'),
+    format = 'file'
+  )
 )

--- a/3_extract.R
+++ b/3_extract.R
@@ -1,6 +1,7 @@
 source('3_extract/src/process_glm_output.R')
 
 p3 <- list(
+  ##### Extract GCM model output #####
   # Use grouped target to combine glm output into feather files
   # Function will generate the output feather file for each lake-gcm combo
   # across all three time periods, truncating the output to the valid dates 
@@ -40,4 +41,7 @@ p3 <- list(
     format = 'file',
     pattern = map(p3_glm_uncalibrated_output_feather_groups)
   )
+  
+  ##### Extract NLDAS model output #####
+  
 )

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -1,25 +1,22 @@
 #' @title Combine output from GLM model runs
-#' @description function to read in the raw output from the 3 GLM
-#' runs for each fully successful lake-gcm combo (set by grouping of 
-#' `p2_glm_uncalibrated_run_groups`), remove the ice thickness, 
+#' @description function to read in the raw output from successful
+#' GLM runs using GCM or NLDAS drivers, remove the ice thickness, 
 #' evaporation, and n_layers variables (leaving the temperature 
 #' predictions and ice flags), filter that output to exclude the
 #' burn-in and burn-out periods, and save the result as a single 
 #' feather file
-#' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
-#' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
-#' to the site_id, gcm, time_period, gcm_start_date, gcm_end_date, export_fl,  
-#' and export_fl_hash columns and grouped by site_id and gcm. Then filtered  
-#' to only groups for which glm_success==TRUE for all runs in that group. 
-#' The function maps over these groups.
+#' @param run_group a single group of successful model runs. If the
+#' passed runs are GCM runs, this group includes all runs for a lake-gcm combo
+#' (nrows = 3). If the passed runs are NLDAS runs, this group includes all
+#' runs for a given lake (nrows = 1). The function maps over these groups.
 #' @param outfile_template the template for the name of the
 #' final output feather file
 #' @return a single feather file with the output temperature predictions
-#' and ice flags for that lake-gcm combo, filtered to the valid dates 
-#' from each time period
-combine_glm_output <- function(run_group, outfile_template) {
+#' and ice flags for that lake-gcm combo (if GCM runs) or lake (if NLDAS runs), 
+#' filtered to the valid dates (excluding burn-in/out from each time period)
+write_glm_output <- function(run_group, outfile_template) {
   # set filename
-  outfile <- sprintf(outfile_template, unique(run_group$site_id), unique(run_group$gcm))
+  outfile <- sprintf(outfile_template, unique(run_group$site_id), unique(run_group$driver))
   
   # combine into single feather file and write,
   # saving only the temperature predictions and ice flags, and
@@ -32,7 +29,7 @@ combine_glm_output <- function(run_group, outfile_template) {
     # the predictions based on the defined start and end dates
     arrow::read_feather(current_run$export_fl) %>%
       select(-hice, -evap, -n_layers) %>%
-      filter(time >= current_run$gcm_start_date & time <= current_run$gcm_end_date)
+      filter(time >= current_run$driver_start_date & time <= current_run$driver_end_date)
   }) %>% 
     arrow::write_feather(outfile)
   
@@ -43,15 +40,16 @@ combine_glm_output <- function(run_group, outfile_template) {
 #' feather files
 #' @description Generate a tibble with a row for each output file
 #' (unique to each lake-gcm combo) that includes its filename and its 
-#' hash along with the site_id, gcm, the state the lake is in, and the 
+#' hash along with the site_id, driver (gcm_name), the state the lake is in, and the 
 #' GCM spatial_cell_no, spatial_tile_no, data_cell_no, and data_tile_no 
 #' for that lake.
-#' @param run_group a single group from the `p2_glm_uncalibrated_run_groups`
-#' grouped version of the `p2_glm_uncalibrated_runs` output tibble subset 
-#' to the site_id, gcm, time_period, raw_meteo_fl, export_fl, and 
-#' export_fl_hash columns and grouped by site_id and gcm. Then filtered to 
-#' only groups for which glm_success==TRUE for all runs in that group. 
-#' The function maps over these groups.
+#' @param run_group a single group from the `p2_gcm_glm_uncalibrated_run_groups`
+#' grouped version of the `p2_gcm_glm_uncalibrated_runs` output tibble subset 
+#' to the site_id, driver (gcm name), time_period, gcm_start_date, gcm_end_date, 
+#' export_fl, and export_fl_hash columns and grouped by site_id. Then filtered  
+#' to only groups for which glm_success==TRUE for all runs in that group. And
+#' then regrouped by site_id and driver (gcm name). The function maps over 
+#' these groups.
 #' @param output_feather A single feather file name from the list of 
 #' output feather file names returned by `combine_glm_output()`. 
 #' The function maps over these file names.
@@ -61,13 +59,13 @@ combine_glm_output <- function(run_group, outfile_template) {
 #' `data_tile_no`). `data_cell_no` will only differ from `spatial_cell_no` 
 #' for those lakes that fall within gcm cells that are missing data.
 #' @return A tibble with one row per lake-gcm output feather file which 
-#' includes the site_id, gcm, the name of the export feather file, its hash,
-#' the state the lake is in, and the GCM spatial_cell_no, spatial_tile_no, 
+#' includes the site_id, driver (gcm name), the name of the export feather file,
+#' its hash, the state the lake is in, and the GCM spatial_cell_no, spatial_tile_no, 
 #' data_cell_no, and data_tile_no for that lake.
 generate_output_tibble <- function(run_group, output_feather, lake_cell_tile_xwalk) {
   export_tibble <- tibble(
       site_id = unique(run_group$site_id),
-      gcm = unique(run_group$gcm),
+      driver = unique(run_group$driver),
       export_fl = output_feather,
       export_fl_hash = tools::md5sum(output_feather)
     ) %>% 
@@ -77,18 +75,13 @@ generate_output_tibble <- function(run_group, output_feather, lake_cell_tile_xwa
 }
 
 #' @title Zip up output from GLM model runs
-#' @description function to zip up the feather files for all lake-gcm
-#' combos according to the spatial_tile_no associated with each lake
-#' @param feather_group A single group of output feather files associated 
-#' with one tile, from the `p3_glm_uncalibrated_output_feather_groups` 
-#' grouped version of the `p3_glm_uncalibrated_output_feather_tibble` 
-#' target grouped by spatial_tile_no. The function maps over these groups.
-#' @param zipfile_template the template for the name of the final zipped
-#' file of feather files, which will be customized with the spatial_tile_no
+#' @description function to zip up output feather files
+#' @param files_to_zip A single group of output feather files. If for GCM
+#' runs, these feather files are associated with one spatial tile. If for
+#' NLDAS runs, these are all NLDAS output files
+#' @param zipfile_out the name of the final zipped file of feather files
 #' @return the name of the zipped file 
-zip_output_files <- function(feather_group, zipfile_template) {
-  files_to_zip <- feather_group$export_fl
-  zipfile_out <- sprintf(zipfile_template, unique(feather_group$spatial_tile_no))
+zip_output_files <- function(files_to_zip, zipfile_out) {
   # In order to use `zip`, you need to be in the same working directory as
   # the files you want to zip up.
   project_dir <- getwd()

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -13,93 +13,93 @@ p4 <- list(
   
   # Plots for each lake-gcm combo
   # Subset p2_glm_uncalibrated_run_groups to selected plotting site_ids
-  tar_target(p4_subset_run_groups,
-             p2_glm_uncalibrated_run_groups %>%
+  tar_target(p4_subset_gcm_run_groups,
+             p2_gcm_glm_uncalibrated_run_groups %>%
                filter(site_id %in% p4_plot_site_ids)  %>%
-               group_by(site_id, gcm) %>% 
+               group_by(site_id, driver) %>% 
                tar_group(),
              iteration = 'group'),
   
   # Pull GLM preds for each lake-gcm combo for each of the plot site ids
-  tar_target(p4_run_glm_preds,
-             get_site_preds(p4_subset_run_groups),
-             pattern = map(p4_subset_run_groups)),
+  tar_target(p4_run_gcm_glm_preds,
+             get_site_preds(p4_subset_gcm_run_groups),
+             pattern = map(p4_subset_gcm_run_groups)),
   
   # Munge the GLM preds to long format
-  tar_target(p4_run_glm_preds_long,
-             munge_long(p4_run_glm_preds),
-             pattern = map(p4_run_glm_preds)),
+  tar_target(p4_run_gcm_glm_preds_long,
+             munge_long(p4_run_gcm_glm_preds),
+             pattern = map(p4_run_gcm_glm_preds)),
   
   # Get mean of GLM predictions for each lake-gcm combo for each DOY within 
   # each period, averaging across all years within each period
-  tar_target(p4_run_glm_mean_long,
-             p4_run_glm_preds_long %>%
-               group_by(site_id, gcm, depth, doy, period) %>%
+  tar_target(p4_run_gcm_glm_mean_long,
+             p4_run_gcm_glm_preds_long %>%
+               group_by(site_id, driver, depth, doy, period) %>%
                summarize(mean_temp = mean(temperature, na.rm=TRUE)) %>%
                filter(!is.na(mean_temp)),
-             pattern = map(p4_run_glm_preds_long)),
+             pattern = map(p4_run_gcm_glm_preds_long)),
   
   # Plot predicted surface, middle, and bottom temperatures in each 
   # lake, for each GCM
   tar_target(
     p4_20yr_gcm_preds_ice,
-    plot_20yr_preds_ice(p4_run_glm_preds_long,
-                        p4_run_glm_mean_long,
+    plot_20yr_preds_ice(p4_run_gcm_glm_preds_long,
+                        p4_run_gcm_glm_mean_long,
                         all_gcms = FALSE,
-                        outfile_template <- '4_visualize/out/Site_20yr_preds_ice_%s_%s.png'),
-    pattern = map(p4_run_glm_preds, p4_run_glm_preds_long, p4_run_glm_mean_long),
+                        outfile_template <- '4_visualize/out/GCM_site_20yr_preds_ice_%s_%s.png'),
+    pattern = map(p4_run_gcm_glm_preds, p4_run_gcm_glm_preds_long, p4_run_gcm_glm_mean_long),
     format='file'),
   
   # Plots for each lake
   # Subset p2_glm_uncalibrated_lake_groups to selected plotting site_ids
-  tar_target(p4_subset_lake_groups,
-             p2_glm_uncalibrated_lake_groups %>%
+  tar_target(p4_subset_gcm_lake_groups,
+             p2_gcm_glm_uncalibrated_lake_groups %>%
                filter(site_id %in% p4_plot_site_ids) %>%
                group_by(site_id) %>% 
                tar_group(),
              iteration = 'group'),
   
   # Pull GLM preds for all 6 GCMs for each of the plot site ids
-  tar_target(p4_lake_glm_preds,
-             get_site_preds(p4_subset_lake_groups),
-             pattern = map(p4_subset_lake_groups)),
+  tar_target(p4_lake_gcm_glm_preds,
+             get_site_preds(p4_subset_gcm_lake_groups),
+             pattern = map(p4_subset_gcm_lake_groups)),
   
   # Munge the GLM preds to long format
-  tar_target(p4_lake_glm_preds_long,
-             munge_long(p4_lake_glm_preds),
-             pattern = map(p4_lake_glm_preds)),
+  tar_target(p4_lake_gcm_glm_preds_long,
+             munge_long(p4_lake_gcm_glm_preds),
+             pattern = map(p4_lake_gcm_glm_preds)),
   
   # Get mean of GLM predictions for each lake for each DOY within each period,
   # averaging across all 6 GCMs and all years within each period
-  tar_target(p4_lake_glm_mean_long,
-             p4_lake_glm_preds_long %>%
+  tar_target(p4_lake_gcm_glm_mean_long,
+             p4_lake_gcm_glm_preds_long %>%
                group_by(site_id, depth, doy, period) %>%
                summarize(mean_temp = mean(temperature, na.rm=TRUE)) %>%
                filter(!is.na(mean_temp)),
-             pattern = map(p4_lake_glm_preds_long)),
+             pattern = map(p4_lake_gcm_glm_preds_long)),
   
   # Plot predicted surface, middle, and bottom temperatures in each 
   # lake, for all 6 GCMs
   tar_target(
-    p4_20yr_average_preds_ice,
-    plot_20yr_preds_ice(p4_lake_glm_preds_long,
-                        p4_lake_glm_mean_long,
+    p4_20yr_average_gcm_preds_ice,
+    plot_20yr_preds_ice(p4_lake_gcm_glm_preds_long,
+                        p4_lake_gcm_glm_mean_long,
                         all_gcms = TRUE,
-                        outfile_template <- '4_Visualize/out/Site_20yr_preds_ice_%s.png'),
-    pattern = map(p4_lake_glm_preds, p4_lake_glm_preds_long, p4_lake_glm_mean_long),
+                        outfile_template <- '4_Visualize/out/GCM_site_20yr_preds_ice_%s.png'),
+    pattern = map(p4_lake_gcm_glm_preds, p4_lake_gcm_glm_preds_long, p4_lake_gcm_glm_mean_long),
     format = 'file'
   ),
   
   # Plot predicted temperature profiles in a given lake, for all 6 GCMs,
   # across all years, for 4 specified dates
   tar_target(
-    p4_20yr_average_profiles,
+    p4_20yr_average_gcm_profiles,
     plot_20yr_average_profiles(p4_plot_site_ids,
-                               p4_lake_glm_preds_long,
-                               p4_lake_glm_mean_long,
+                               p4_lake_gcm_glm_preds_long,
+                               p4_lake_gcm_glm_mean_long,
                                plot_month_days = c('02-15','05-15','08-15','11-15'),
-                               outfile_template <- '4_Visualize/out/Site_20yr_profiles_%s.png'),
-    pattern = map(p4_plot_site_ids, p4_lake_glm_preds_long, p4_lake_glm_mean_long),
+                               outfile_template <- '4_Visualize/out/GCM_site_20yr_profiles_%s.png'),
+    pattern = map(p4_plot_site_ids, p4_lake_gcm_glm_preds_long, p4_lake_gcm_glm_mean_long),
     format = 'file'
   ),
   
@@ -107,27 +107,27 @@ p4 <- list(
   # Plots for all lakes
   # Get surface, middle, and bottom predictions for all lakes, across all GCMs
   tar_target(
-    p4_glm_preds,
-    get_surface_middle_bottom_preds(p2_glm_uncalibrated_run_groups)
+    p4_gcm_glm_preds,
+    get_surface_middle_bottom_preds(p2_gcm_glm_uncalibrated_run_groups)
   ),
   
   # Create a violin chart of predicted surface, middle, and bottom 
-  # temperatures in all lakes for all GCMs, faceted by gcm
+  # temperatures in all lakes for all GCMs, faceted by driver (gcm name)
   tar_target(
-    p4_temp_violin_gcms,
-    plot_temp_violin(p4_glm_preds,
-                     faceting_variable = 'gcm',
-                     outfile = '4_visualize/out/temperature_violin_gcms.png'),
+    p4_gcm_temp_violin_gcms,
+    plot_temp_violin(p4_gcm_glm_preds,
+                     faceting_variable = 'driver',
+                     outfile = '4_visualize/out/GCM_temperature_violin_gcms.png'),
     format='file'
   ),
   
   # Create a violin chart of predicted surface, middle, and bottom 
   # temperatures in all lakes for all GCMs, faceted by month
   tar_target(
-    p4_temp_violin_months,
-    plot_temp_violin(p4_glm_preds,
+    p4_gcm_temp_violin_months,
+    plot_temp_violin(p4_gcm_glm_preds,
                      faceting_variable = 'month',
-                     outfile = '4_visualize/out/temperature_violin_months.png'),
+                     outfile = '4_visualize/out/GCM_temperature_violin_months.png'),
     format='file'
   )
 )

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ singularity pull docker://jrossusgs/glm3r:v0.7
 ```
 Here's how to build targets using the Singularity container and the `targets::tar_make_clustermq(target_name, workers=n_workers)` option to build targets in parallel within the Singularity container, with a specified number of workers (up to 72, as Tallgrass has 72 cores per node). The `srun` command will allocate a node and then run the specified command, in this case `Rscript`. Targets will then delegate work out to `n_workers` cores for any parallelizable step that you don't specifically tell it to run in serial.
 ```R
-srun --pty -c 10 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_glm_uncalibrated_runs, workers=10)'
+srun --pty -c 10 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=10)'
 ```
 
 Here's how to run the Singularity container interactively on an allocated job:
 ```R
-srun --pty -c 10  -A watertemp singularity exec glm3r_v0.7.sif bash
+srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r_v0.7.sif bash
 R
 library(targets)
-tar_make_clustermq(p2_glm_uncalibrated_runs, workers=79)
+tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=72)
 # etc
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This repository is for running uncalibrated GLM models of lake temperatures.
 
-|                                                                                                                                                                                    |
-|-------------------|
-| \## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) *Files that will eventually be transferred using GLOBUS:* |
+-------------------
+# Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) 
+*Files that will eventually be transferred using GLOBUS:*
+* Lake - GCM cell tile crosswalk: '1_prep/in/lake_cell_tile_xwalk.csv'
+  * Created within the [targets sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R), look for the lake_cell_tile_xwalk_df target
+* List of lake-specific attributes for nml modification: '1_prep/in/nml_list.rds'
+* Munged GCM netCDF files (one per GCM)
 
 ## Running the pipeline on HPC, in parallel
 
@@ -37,23 +41,21 @@ singularity pull docker://jrossusgs/glm3r:v0.7
 # now you can see the singularity image: it is a file called glm3r_v0.7.sif
 ```
 
-### Running the pipeline in the Singularity container
+**Running the pipeline in the Singularity container**
 
 Here's how to build targets using the Singularity container and the `targets::tar_make_clustermq(target_name, workers=n_workers)` option to build targets in parallel within the Singularity container, with a specified number of workers (up to 72, as Tallgrass has 72 cores per node). The `srun` command will allocate a node and then run the specified command, in this case `Rscript`. Targets will then delegate work out to `n_workers` cores for any parallelizable step that you don't specifically tell it to run in serial.
 
-##### Building the GCM-driven GLM models, in parallel
-
 ``` r
+# Build GCM-driven GLM models, in parallel
 srun --pty -c 72 -t 7:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=60)'
 ```
 
-##### Building the NLDAS-driven GLM models
-
 ``` r
+# Build NLDAS-driven GLM models, in parallel
 srun --pty -c 72 -t 1:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_nldas_glm_uncalibrated_runs, workers=60)'
 ```
 
-#### Running the pipeline interactively
+**Running the pipeline interactively**
 
 Here's how to run the Singularity container interactively on an allocated job:
 
@@ -65,7 +67,7 @@ tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=72)
 # etc
 ```
 
-#### Editing the pipeline in RStudio on Tallgrass
+**Editing the pipeline in RStudio on Tallgrass**
 
 You can also get an interactive RStudio on tallgrass. The best documentation for this is currently [here](https://code.usgs.gov/wma/wp/pump-temperature#running-interactive-sessions-on-hpc). The tl;dr is
 
@@ -78,7 +80,7 @@ squeue -u jross
 cat tmp/rstudio_jross.out
 ```
 
-##### Caution
+**_Caution_**
 
 RStudio may not be as good an environment for running parallelized targets pipelines as running them through `Rscript -e`. The [clustermq user guide](https://cran.r-project.org/web/packages/clustermq/vignettes/userguide.html) says that the `multicore` scheduler sometimes causes problems in RStudio. I haven't run into this, but if it happens, you might need to switch to `multiprocess`. This uses more RAM. Might not be a problem, just something to be aware of!
 
@@ -126,5 +128,5 @@ docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -p 8787:8787
 ``` r
 setwd("/lakes") 
 # Do a lot of work at once and test your computer's fan
-targets::tar_make_clustermq(p2_glm_uncalibrated_runs, workers = 32)
+targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers = 32)
 ```

--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 This repository is for running uncalibrated GLM models of lake temperatures.
 
 -------------------
-# Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) 
-*Files that will eventually be transferred using GLOBUS:*
-* Lake - GCM cell tile crosswalk: '1_prep/in/lake_cell_tile_xwalk.csv'
+## Dependent files 
+* NLDAS driver files
+  * _e.g._, `'1_prep/in/NLDAS_time[0.379366]_x[231]_y[167].csv'`
+
+*Files  from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) that will eventually be transferred using GLOBUS:*
+* List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
+* Lake - GCM cell tile crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
   * Created within the [targets sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R), look for the lake_cell_tile_xwalk_df target
-* List of lake-specific attributes for nml modification: '1_prep/in/nml_list.rds'
 * Munged GCM netCDF files (one per GCM)
+
+
 
 ## Running the pipeline on HPC, in parallel
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # GLM modeling of lake temperatures
+
 This repository is for running uncalibrated GLM models of lake temperatures.
 
------------------
-## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep)
-_Files that will eventually be transferred using GLOBUS:_
-  * Lake - GCM cell tile crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
-    * Created within [the `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R), look for the `lake_cell_tile_xwalk_df` target
-  * List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
-  * Munged GCM netCDF files (one per GCM)
-  
------------------
+|                                                                                                                                                                                    |
+|-------------------|
+| \## Dependent files from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) *Files that will eventually be transferred using GLOBUS:* |
 
 ## Running the pipeline on HPC, in parallel
 
 ### Tallgrass quickstart
-```R
+
+``` r
 ssh tallgrass.cr.usgs.gov
 cd /caldera/projects/usgs/water/iidd/datasci/lake-temp/lake-temperature-process-models
 
@@ -24,26 +20,44 @@ umask 002
 ```
 
 ### Singularity
+
 Singularity is a program for running code in containers. It is fundamentally similar to docker, and is capable of generating containers based on docker images. It is the containerization technology used in the tallgrass and yeti HPC environments. For more information, see [here](https://code.usgs.gov/wwatkins/hpc_container_blog).
 
 For the following applications, you'll need to load the singularity and slurm modules:
 
-```bash
+``` bash
 module load singularity slurm
 ```
+
 Here's how to get the image that Jesse built from Dockerhub and translate it to Singularity (this has already been done for the image listed below, and should only need to be re-done if a new image is built):
-```bash
+
+``` bash
 cd /caldera/projects/usgs/water/iidd/datasci/lake-temp/lake-temperature-process-models
 singularity pull docker://jrossusgs/glm3r:v0.7
 # now you can see the singularity image: it is a file called glm3r_v0.7.sif
 ```
+
+### Running the pipeline in the Singularity container
+
 Here's how to build targets using the Singularity container and the `targets::tar_make_clustermq(target_name, workers=n_workers)` option to build targets in parallel within the Singularity container, with a specified number of workers (up to 72, as Tallgrass has 72 cores per node). The `srun` command will allocate a node and then run the specified command, in this case `Rscript`. Targets will then delegate work out to `n_workers` cores for any parallelizable step that you don't specifically tell it to run in serial.
-```R
-srun --pty -c 10 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=10)'
+
+##### Building the GCM-driven GLM models, in parallel
+
+``` r
+srun --pty -c 72 -t 7:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=60)'
 ```
 
+##### Building the NLDAS-driven GLM models
+
+``` r
+srun --pty -c 72 -t 1:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_nldas_glm_uncalibrated_runs, workers=60)'
+```
+
+#### Running the pipeline interactively
+
 Here's how to run the Singularity container interactively on an allocated job:
-```R
+
+``` r
 srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r_v0.7.sif bash
 R
 library(targets)
@@ -51,9 +65,11 @@ tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=72)
 # etc
 ```
 
+#### Editing the pipeline in RStudio on Tallgrass
+
 You can also get an interactive RStudio on tallgrass. The best documentation for this is currently [here](https://code.usgs.gov/wma/wp/pump-temperature#running-interactive-sessions-on-hpc). The tl;dr is
 
-```bash
+``` bash
 # Launch the session
 sbatch launch-rstudio-container.slurm
 # Make sure the session is running on a compute node
@@ -62,31 +78,36 @@ squeue -u jross
 cat tmp/rstudio_jross.out
 ```
 
-### Caution
+##### Caution
+
 RStudio may not be as good an environment for running parallelized targets pipelines as running them through `Rscript -e`. The [clustermq user guide](https://cran.r-project.org/web/packages/clustermq/vignettes/userguide.html) says that the `multicore` scheduler sometimes causes problems in RStudio. I haven't run into this, but if it happens, you might need to switch to `multiprocess`. This uses more RAM. Might not be a problem, just something to be aware of!
 
------------------
+------------------------------------------------------------------------
 
 ## Building the Docker image
 
 This is as simple as editing the Dockerfile and running a command to rebuild it. What follows is a teaser. It won't be as simple as this, because currently the image is hosted on Jesse's Docker Hub. We should put the image on the CHS docker server instead, but we can wait until when (or, if) it needs to be built again to do so.
 
-```bash
+``` bash
 cd docker
 docker-compose build   # maybe change version tag in docker-compose.yml first
 docker-compose up      # test it
 docker-compose push    # push the updated image to the server
 ```
 
------------------
+------------------------------------------------------------------------
+
 ## Running the pipeline locally, in serial
+
 You can simply build targets as normal, using `tar_make()`, and `targets` will ignore the `cluster_mq.scheduler` options set in `'_targets.R'`
 
 ## Running the pipeline locally, in parallel
+
 The pipeline can be run in parallel locally through docker, just as it can be run through Singularity on tallgrass.
 
 Simple command-line R interface:
-```bash
+
+``` bash
 docker pull jrossusgs/glm3r:v0.7
 cd ~/lake-temperature-process-models
 docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -it jrossusgs/glm3r:v0.7 R
@@ -95,13 +116,14 @@ docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -it jrossusg
 ```
 
 Or alternatively, you could run RStudio in the container and access it through your browser (user is rstudio, password set in the startup command as mypass).
-```bash
+
+``` bash
 docker pull jrossusgs/glm3r:v0.7
 cd ~/lake-temperature-process-models
 docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -p 8787:8787 -e PASSWORD=mypass -e ROOT=TRUE -d jrossusgs/glm3r:v0.7
 ```
 
-```r
+``` r
 setwd("/lakes") 
 # Do a lot of work at once and test your computer's fan
 targets::tar_make_clustermq(p2_glm_uncalibrated_runs, workers = 32)


### PR DESCRIPTION
Alright - NLDAS models are up and running locally, and are ready to be launched on Tallgrass once this code is approved and merged in. The NLDAS data runs from 1/2/1979 - 4/11/2022. At the moment, per a discussion w/ Jordan, I'm using 1979 for burn-in and 2022 for burn-out, and cropping the output to 1/1/1980-12/31/2021, as that was fastest to set up. In the future we could choose to take the approach we did with the GCM data and add burn-in/out by mirroring the raw data, which would make full use of the available NLDAS data and extend our simulation period.

This should hopefully be a quick review. The substantive code edits were to set up the dates that define the NLDAS model runs `p1_nldas_dates` and build the NLDAS model configuration `p1_nldas_model_config`. The NLDAS models are run using the existing model execution code. The NLDAS results are packaged up using the existing code to process the glm output, with minor edits to make those functions more flexible and update the function documentation.

*Primary edits to set up NLDAS runs:*
* Set up dates that define model run, burn-in, burn-out and how the final data will be cropped
* Build configuration for for NLDAS models
* Build nmls for NLDAS model runs
* Add targets to run NLDAS GLM models (1 model per lake)
* Add targets to extract NLDAS output

*Minor additional edits per our discussion:*
* Rearrange targets into sections
* Add 'driver_type' argument to function to munge model nmls
* Update names of GCM targets to include 'gcm', for clarity
* Switch the GCM configuration column names from 'gcm', 'gcm_start_date', and 'gcm_end_date' to 'driver', 'driver_start_date', and 'driver_end_date' 
* Streamline functions in `'process_glm_output.R'` so that can be called to process GCM or NLDAS GLM output and update function documentation accordingly
* Update p4 targets and scripts to reflect those ^ changes to target and column names