### PR TITLE
Reduce to max of 2 retries

### DIFF
--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -104,7 +104,7 @@ run_glm3_model <- function(sim_dir, nml_obj, model_config, export_fl_template) {
           max_output_date <- max(output_dates)
         },
         until=function(val, cnd) glm_code == 0 & max_output_date==sim_stop,
-        max_tries = 5)
+        max_tries = 2)
       
       # make sure glm did succeed  
       if(glm_code != 0 | max_output_date!=sim_stop) stop()


### PR DESCRIPTION
In main codebase, drop from 5 to 2 `max_tries` within the `retry()` code chunk. This makes it consistent with how we've been running model runs on Tallgrass -- those have been run within the `denali_glm_tests` branch on Tallgrass, which makes this reduction and also times different parts of the `run_glm3_model()` Function. For the next full re-runs I'd like to run on the `main` branch and keep that drop in `max_tries` but not the timing variables, as they increase the size of the tibble returned by `run_glm3_model()`