### PR TITLE
Expand NLDAS runs to full footprint

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -13,6 +13,7 @@ p1 <- list(
   tar_target(p1_nml_list_rds, '1_prep/in/nml_list.rds', format = 'file'),
   tar_target(p1_nml_site_ids, names(readr::read_rds(p1_nml_list_rds))),
   # lake-to-state xwalk, filtered to only those lakes that are in nml list (able to be modeled by GLM)
+  # used to define site_ids for NLDAS runs, not for GCM runs
   # file copied from lake-temperature-model-prep repo '2_crosswalk_munge/out/lake_to_state_xwalk.rds'
   tar_target(p1_lake_to_state_xwalk_rds, '1_prep/in/lake_to_state_xwalk.rds', format='file'),
   tar_target(p1_lake_to_state_xwalk_df,
@@ -21,6 +22,7 @@ p1 <- list(
                arrange(site_id)),
   # lake - GCM cell - GCM tile crosswalk, filtered to only those lakes
   # that are in nml list (able to be modeled by GLM)
+  # used to define site_ids for GCM runs
   # file copied from lake-temperature-model-prep repo '7_drivers_munge/out/lake_cell_tile_xwalk.csv'
   tar_target(p1_lake_cell_tile_xwalk_csv, '1_prep/in/lake_cell_tile_xwalk.csv', format = 'file'),
   tar_target(p1_lake_cell_tile_xwalk_df, 

--- a/1_prep.R
+++ b/1_prep.R
@@ -9,25 +9,32 @@ p1 <- list(
   ##### Pull in files from lake-temperature-model-prep #####
   # TODO - transfer to Denali using globus
   # list of lake-specific attributes for nml modification
-  # file copied from lake-temperature-model-prep repo
+  # file copied from lake-temperature-model-prep repo '7_config_merge/out/nml_list.rds'
   tar_target(p1_nml_list_rds, '1_prep/in/nml_list.rds', format = 'file'),
   tar_target(p1_nml_site_ids, names(readr::read_rds(p1_nml_list_rds))),
+  # lake-to-state xwalk, filtered to only those lakes that are in nml list (able to be modeled by GLM)
+  # file copied from lake-temperature-model-prep repo '2_crosswalk_munge/out/lake_to_state_xwalk.rds'
+  tar_target(p1_lake_to_state_xwalk_rds, '1_prep/in/lake_to_state_xwalk.rds', format='file'),
+  tar_target(p1_lake_to_state_xwalk_df,
+             readr::read_rds(p1_lake_to_state_xwalk_rds) %>%
+               filter(site_id %in% p1_nml_site_ids) %>%
+               arrange(site_id)),
   # lake - GCM cell - GCM tile crosswalk, filtered to only those lakes
   # that are in nml list (able to be modeled by GLM)
-  # file copied from lake-temperature-model-prep repo
+  # file copied from lake-temperature-model-prep repo '7_drivers_munge/out/lake_cell_tile_xwalk.csv'
   tar_target(p1_lake_cell_tile_xwalk_csv, '1_prep/in/lake_cell_tile_xwalk.csv', format = 'file'),
   tar_target(p1_lake_cell_tile_xwalk_df, 
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
                filter(site_id %in% p1_nml_site_ids) %>%
-               arrange(site_id)), 
-  
-  ##### Define vector of site ids and subset nml list #####
-  # Pull vector of site ids
-  tar_target(p1_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
-  # Subset nml list
-  tar_target(p1_nml_list_subset, readr::read_rds(p1_nml_list_rds)[p1_site_ids]),
+               arrange(site_id)),
   
   ##### GCM model set up #####
+  # Pull vector of site ids
+  tar_target(p1_gcm_site_ids, p1_lake_cell_tile_xwalk_df %>% pull(site_id)),
+  
+  # Subset nml list
+  tar_target(p1_gcm_nml_list_subset, readr::read_rds(p1_nml_list_rds)[p1_gcm_site_ids]),
+  
   # Define mapping variables
   tar_target(p1_gcm_names, c('ACCESS', 'GFDL', 'CNRM', 'IPSL', 'MRI', 'MIROC5')),
   tar_target(p1_gcm_time_periods, c('1981_2000', '2040_2059', '2080_2099')),
@@ -71,25 +78,31 @@ p1 <- list(
   
   # Set up list of nml objects, with NULL for meteo_fl, and custom depth parameters
   # Transform a single file of all lakes to a single list of all lakes
-  # (subset to p1_site_ids), then tell `targets` to think of that list as an iterable list
+  # (subset to p1_gcm_site_ids), then tell `targets` to think of that list as an iterable list
   tar_target(p1_gcm_nml_objects,
-             munge_model_nmls(nml_list = p1_nml_list_subset,
+             munge_model_nmls(nml_list = p1_gcm_nml_list_subset,
                         base_nml = p1_glm_template_nml,
                         driver_type = 'gcm'),
              packages = c('glmtools'),
              iteration = 'list'),
   
   ##### NLDAS model set up #####
+  # Pull vector of site ids
+  tar_target(p1_nldas_site_ids, p1_lake_to_state_xwalk_df %>% pull(site_id)),
+  
+  # Subset nml list
+  tar_target(p1_nldas_nml_list_subset, readr::read_rds(p1_nml_list_rds)[p1_nldas_site_ids]),
+  
   # Define NLDAS time period
   tar_target(p1_nldas_time_period, c('1980_2021')),
   
   # track unique NLDAS meteo files
-  # length(p1_nldas_csvs) = # of unique NLDAS files associated with p1_site_ids
+  # length(p1_nldas_csvs) = # of unique NLDAS files associated with p1_nldas_site_ids
   tar_target(p1_nldas_csvs,
              {
                nldas_files <- c()
-               for (site_id in p1_site_ids) {
-                 site_nml <- p1_nml_list_subset[[site_id]]
+               for (site_id in p1_nldas_site_ids) {
+                 site_nml <- p1_nldas_nml_list_subset[[site_id]]
                  site_nldas_file <- file.path('1_prep/in/NLDAS_GLM_csvs', site_nml$meteo_fl)
                  if (!(site_nldas_file %in% nldas_files)) {
                    nldas_files <- c(nldas_files, site_nldas_file)
@@ -110,12 +123,12 @@ p1 <- list(
 
   # Set up NLDAS model config
   tar_target(p1_nldas_model_config,
-             build_nldas_model_config(p1_site_ids, p1_nml_list_subset, p1_nldas_csvs, p1_nldas_dates)
+             build_nldas_model_config(p1_nldas_site_ids, p1_nldas_nml_list_subset, p1_nldas_csvs, p1_nldas_dates)
   ),
   
   # Set up nmls for NLDAS model runs
   tar_target(p1_nldas_nml_objects,
-             munge_model_nmls(nml_list = p1_nml_list_subset,
+             munge_model_nmls(nml_list = p1_nldas_nml_list_subset,
                               base_nml = p1_glm_template_nml,
                               driver_type = 'nldas'),
              packages = c('glmtools'),

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ This repository is for running uncalibrated GLM models of lake temperatures.
 
 -------------------
 ## Dependent files 
-* NLDAS driver files
+* GLM 3 template
+  * `'1_prep/in/glm3_template.nml'` (committed to repo)
+* NLDAS driver files (stored on Caldera)
   * _e.g._, `'1_prep/in/NLDAS_time[0.379366]_x[231]_y[167].csv'`
 
-*Files  from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) that will eventually be transferred using GLOBUS:*
-* List of lake-specific attributes for nml modification: `'1_prep/in/nml_list.rds'`
-* Lake - GCM cell tile crosswalk: `'1_prep/in/lake_cell_tile_xwalk.csv'`
+*Files  from [`lake-temperature-model-prep pipeline`](https://github.com/USGS-R/lake-temperature-model-prep) that will eventually be transferred using GLOBUS (location in `lake-temperature-model-prep` --> location in this pipeline):*
+* List of lake-specific attributes for nml modification: `'7_config_merge/out/nml_list.rds'` --> `'1_prep/in/nml_list.rds'`
+* Lake-to-state crosswalk: `'2_crosswalk_munge/out/lake_to_state_xwalk.rds'` --> `'1_prep/in/lake_to_state_xwalk.rds'`
+* Lake - GCM cell tile crosswalk: `'7_drivers_munge/out/lake_cell_tile_xwalk.csv'` --> `'1_prep/in/lake_cell_tile_xwalk.csv'`
   * Created within the [targets sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R), look for the lake_cell_tile_xwalk_df target
-* Munged GCM netCDF files (one per GCM)
+* Munged GCM netCDF files (one per GCM): `'7_drivers_munge/out/GCM_{gcm name}.nc'` --> `'1_prep/in/GCM_{gcm name}.nc'`
 
 
 


### PR DESCRIPTION
Expand NLDAS runs to full footprint by updating how NLDAS site_ids are defined. Brings in the [`lake_to_state_xwalk.rds`](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/2_crosswalk_munge.yml#L167) from `lake-temperature-model-prep` and then filters those site_ids to those contained in [`p1_nml_list_rds`](https://github.com/USGS-R/lake-temperature-process-models/blob/main/1_prep.R#L13-L14). That results in 9369 GLM-modelable lakes, which matches Julie's [latest PR](https://github.com/USGS-R/lake-temperature-model-prep/pull/340).

I tested these edits on Tallgrass and then completed a full run. The run summary is provided [here](https://github.com/USGS-R/lake-temperature-process-models/discussions/57). 9333 out of 9369 runs succeeded.