### PR TITLE
Document model export files in csv

### DIFF
--- a/3_extract.R
+++ b/3_extract.R
@@ -20,8 +20,22 @@ p3 <- list(
   # and the cell_no and tile_no for that lake.
   tar_target(
     p3_gcm_glm_uncalibrated_output_feather_tibble,
-    generate_output_tibble(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers, p1_lake_cell_tile_xwalk_df),
+    generate_output_tibble(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers, 
+                           lake_xwalk = p1_lake_cell_tile_xwalk_df),
     pattern = map(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers)
+  ),
+  
+  # Save summary of output files
+  tar_target(
+    p3_gcm_glm_uncalibrated_output_summary_csv,
+    {
+      outfile <- '3_extract/out/GLM_GCM_summary.csv'
+      p3_gcm_glm_uncalibrated_output_feather_tibble %>%
+        select(site_id, driver, export_fl, export_fl_hash, state) %>%
+        readr::write_csv(outfile)
+      return(outfile)
+    },
+    format = 'file'
   ),
   
   # Group output feather tibble by spatial tile number
@@ -56,6 +70,27 @@ p3 <- list(
     write_glm_output(p2_nldas_glm_uncalibrated_run_groups,
                      outfile_template='3_extract/out/GLM_%s_%s.feather'),
     pattern = map(p2_nldas_glm_uncalibrated_run_groups)
+  ),
+  
+  # Generate a tibble with a row for each output file
+  # that includes the filename and its hash along with the
+  # site_id, driver (NLDAS), and the state the lake is in
+  tar_target(
+    p3_nldas_glm_uncalibrated_output_feather_tibble,
+    generate_output_tibble(p2_nldas_glm_uncalibrated_run_groups, p3_nldas_glm_uncalibrated_output_feathers, 
+                           lake_xwalk = p1_lake_to_state_xwalk_df),
+    pattern = map(p2_nldas_glm_uncalibrated_run_groups, p3_nldas_glm_uncalibrated_output_feathers)
+  ),
+  
+  # Save summary of output files
+  tar_target(
+    p3_nldas_glm_uncalibrated_output_summary_csv,
+    {
+      outfile <- '3_extract/out/GLM_NLDAS_summary.csv'
+      readr::write_csv(p3_nldas_glm_uncalibrated_output_feather_tibble, outfile)
+      return(outfile)
+    },
+    format = 'file'
   ),
   
   # Zip all NLDAS output into a single zip file

--- a/3_extract.R
+++ b/3_extract.R
@@ -93,10 +93,24 @@ p3 <- list(
     format = 'file'
   ),
   
-  # Zip all NLDAS output into a single zip file
+  # Group output feather tibble by state
+  tar_target(
+    p3_nldas_glm_uncalibrated_output_feather_groups,
+    p3_nldas_glm_uncalibrated_output_feather_tibble %>%
+      group_by(state) %>%
+      tar_group(),
+    iteration = "group"
+  ),
+  
+  # Generate a zip file for each state, zipping the grouped feathers
   tar_target(
     p3_nldas_glm_uncalibrated_output_zips,
-    zip_output_files(p3_nldas_glm_uncalibrated_output_feathers, '3_extract/out/GLM_NLDAS.zip'),
-    format = 'file'
+    {
+      files_to_zip <- p3_nldas_glm_uncalibrated_output_feather_groups$export_fl
+      zipfile_out <- sprintf('3_extract/out/GLM_NLDAS_%s.zip', unique(p3_nldas_glm_uncalibrated_output_feather_groups$state))
+      zip_output_files(files_to_zip, zipfile_out)
+    },
+    format = 'file',
+    pattern = map(p3_nldas_glm_uncalibrated_output_feather_groups)
   )
 )

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -39,37 +39,36 @@ write_glm_output <- function(run_group, outfile_template) {
 #' @title Generate a tibble of information about the output
 #' feather files
 #' @description Generate a tibble with a row for each output file
-#' (unique to each lake-gcm combo) that includes its filename and its 
-#' hash along with the site_id, driver (gcm_name), the state the lake is in, and the 
-#' GCM spatial_cell_no, spatial_tile_no, data_cell_no, and data_tile_no 
-#' for that lake.
-#' @param run_group a single group from the `p2_gcm_glm_uncalibrated_run_groups`
-#' grouped version of the `p2_gcm_glm_uncalibrated_runs` output tibble subset 
-#' to the site_id, driver (gcm name), time_period, gcm_start_date, gcm_end_date, 
-#' export_fl, and export_fl_hash columns and grouped by site_id. Then filtered  
-#' to only groups for which glm_success==TRUE for all runs in that group. And
-#' then regrouped by site_id and driver (gcm name). The function maps over 
-#' these groups.
+#' that includes its filename and its hash along with the site_id, 
+#' driver, the state the lake is in, and, if the passed runs are
+#' GCM runs, the GCM spatial_cell_no, spatial_tile_no, data_cell_no, 
+#' and data_tile_no for that lake.
+#' @param run_group a single group of successful model runs. If the
+#' passed runs are GCM runs, this group includes all runs for a lake-gcm combo
+#' (nrows = 3). If the passed runs are NLDAS runs, this group includes all
+#' runs for a given lake (nrows = 1). The function maps over these groups.
 #' @param output_feather A single feather file name from the list of 
-#' output feather file names returned by `combine_glm_output()`. 
+#' output feather file names returned by `write_glm_output()`. 
 #' The function maps over these file names.
-#' @param lake_cell_tile_xwalk - mapping of which lakes fall into which gcm 
-#' cells and tiles (parameters `spatial_cell_no` and `spatial_tile_no`) and 
-#' which gcm cell to use for driver data for each lake (`data_cell_no`,
-#' `data_tile_no`). `data_cell_no` will only differ from `spatial_cell_no` 
-#' for those lakes that fall within gcm cells that are missing data.
-#' @return A tibble with one row per lake-gcm output feather file which 
-#' includes the site_id, driver (gcm name), the name of the export feather file,
-#' its hash, the state the lake is in, and the GCM spatial_cell_no, spatial_tile_no, 
+#' @param lake_xwalk - If the passed runs are GCM runs, this xwalk is a 
+#' mapping of which lakes fall into which gcm cells and tiles (parameters 
+#' `spatial_cell_no` and `spatial_tile_no`) and which gcm cell to use for 
+#' driver data for each lake (`data_cell_no`, `data_tile_no`). `data_cell_no` 
+#' will only differ from `spatial_cell_no` for those lakes that fall within gcm 
+#' cells that are missing data. If the passed runs are NLDAS runs, this xwalk
+#' is a mapping of which state each lake falls within.
+#' @return A tibble with one row per output feather file which includes the 
+#' site_id, driver, the name of the export feather file, its hash, the state 
+#' the lake is in, and (if GCM output) the GCM spatial_cell_no, spatial_tile_no, 
 #' data_cell_no, and data_tile_no for that lake.
-generate_output_tibble <- function(run_group, output_feather, lake_cell_tile_xwalk) {
+generate_output_tibble <- function(run_group, output_feather, lake_xwalk) {
   export_tibble <- tibble(
       site_id = unique(run_group$site_id),
       driver = unique(run_group$driver),
       export_fl = output_feather,
       export_fl_hash = tools::md5sum(output_feather)
     ) %>% 
-    left_join(lake_cell_tile_xwalk, by='site_id')
+    left_join(lake_xwalk, by='site_id')
   
   return(export_tibble)
 }

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -9,15 +9,15 @@ p5 <- list(
   ###### Prep predictions and observations ######
   
   # Get vector of site_ids for which we have NLDAS output
-  tar_target(p3_nldas_export_site_ids,
-             p2_nldas_glm_uncalibrated_run_groups %>%
+  tar_target(p5_nldas_export_site_ids,
+             p3_nldas_glm_uncalibrated_output_feather_tibble %>%
                pull(site_id)),
   
   # Prep site observations
   # filter obs to sites and dates for which we have NLDAS output
   # And further filter obs to those for sites w/ >= `min_obs_dates` dates with observations
   tar_target(p5_obs_for_eval,
-             get_eval_obs(p1_obs_feather, p3_nldas_export_site_ids, p1_nldas_dates$driver_start_date, 
+             get_eval_obs(p1_obs_feather, p5_nldas_export_site_ids, p1_nldas_dates$driver_start_date, 
                           p1_nldas_dates$driver_end_date, min_obs_dates = 10)),
   
   # Get vector of evaluation sites, based on availability of observations


### PR DESCRIPTION
Per a convo w/ Lindsay re: how best to track the latest exported output for downstream steps

- Add a tibble documenting the filename and hash of exported NLDAS feather files (as already exists for GCM feather files), as well as the state that each lake falls within
- Write both export file tibbles to csv
  - These can be used by Lindsay in `lake-temperature-out` to determine which output files to include in downstream steps, rather than going off of string-matching filepaths.
- Use tibble of NLDAS export files to generate zip files of NLDAS output for each state
- Small edit to 5_evaulate to use the new NLDAS output tibble to determine the NLDAS export site ids