### PR TITLE
Add ice layers check

### DIFF
--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -31,20 +31,20 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
     select(-DateTime)
   
   # As a further check of whether or not the model run was successful, 
-  # check if # layers = 1 at any point during the simulation, and 
-  # return an error message if so
+  # check if # layers = 1 at any point during the simulation
+  error_message <- NA
   min_layers <- min(layers_data$n_layers)
   if (min_layers == 1) {
     error_message <- 'Number of layers drops to 1'
-    
-    # also check if max ice thickness exceeds lake depth, since that
-    # is sometimes the reason that the number of layers drops to 1
-    max_hice <- max(ice_data$hice)
-    
-    if (max_hice > lake_depth) {
-      error_message <- sprintf('%s, Maximum hice value exceeds lake depth', error_message)
-    }
-    
+  }
+  # also check if max ice thickness exceeds lake depth
+  max_hice <- max(ice_data$hice)
+  if (max_hice > lake_depth) {
+    error_message <- ifelse(is.na(error_message), 'Maximum hice value exceeds lake depth', sprintf('%s, Maximum hice value exceeds lake depth', error_message)) 
+  }
+  # If either # layers = 1 OR ice thickness > lake_depth, trigger an error
+  # and return the error message
+  if ((min_layers == 1) | (max_hice > lake_depth)) {
     stop(error_message)
   }
 

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -42,9 +42,8 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
   if (max_hice > lake_depth) {
     error_message <- ifelse(is.na(error_message), 'Maximum hice value exceeds lake depth', sprintf('%s, Maximum hice value exceeds lake depth', error_message)) 
   }
-  # If either # layers = 1 OR ice thickness > lake_depth, trigger an error
-  # and return the error message
-  if ((min_layers == 1) | (max_hice > lake_depth)) {
+  # If `error_message` is not NA, trigger an error and return the error message
+  if (!is.na(error_message)) {
     stop(error_message)
   }
 

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -9,9 +9,16 @@
 extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
   lake_depth <- glmtools::get_nml_value(nml_obj, arg_name = 'lake_depth')
   export_depths <- seq(0, lake_depth, by = 0.5)
+  
+  # Extract temperature predictions for simulation
+  # This may trigger an error ('need at least two non-NA values to interpolate')
+  # if the temperature predictions contain NA values. If so, that's documented
+  # as a 'NA temperature values' error in our export tibble returned by `run_glm3_model()`
   temp_data <- glmtools::get_temp(nc_filepath, reference = 'surface', z_out = export_depths) %>%
     mutate(time = as.Date(lubridate::floor_date(DateTime, 'days'))) %>% 
     select(-DateTime)
+  
+  # Extract layers, evaporation, and ice data for simulation
   layers_data <- glmtools::get_var(nc_filepath, 'NS') %>%
     rename(n_layers = NS) %>%
     mutate(time = as.Date(lubridate::ceiling_date(DateTime, ' days'))) %>%
@@ -22,11 +29,25 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
   ice_data <- glmtools::get_var(nc_filepath, var_name = 'hice') %>%
     mutate(ice = hice > 0, time = as.Date(lubridate::ceiling_date(DateTime, ' days'))) %>%
     select(-DateTime)
-  # check if max ice thickness exceeds lake depth
-  max_hice <- max(ice_data$hice)
-  if (max_hice > lake_depth) {
-    stop('Maximum hice value exceeds lake depth')
+  
+  # As a further check of whether or not the model run was successful, 
+  # check if # layers = 1 at any point during the simulation, and 
+  # return an error message if so
+  min_layers <- min(layers_data$n_layers)
+  if (min_layers == 1) {
+    error_message <- 'Number of layers drops to 1'
+    
+    # also check if max ice thickness exceeds lake depth, since that
+    # is sometimes the reason that the number of layers drops to 1
+    max_hice <- max(ice_data$hice)
+    
+    if (max_hice > lake_depth) {
+      error_message <- sprintf('%s, Maximum hice value exceeds lake depth', error_message)
+    }
+    
+    stop(error_message)
   }
+
   all_results <- temp_data %>%
     left_join(ice_data, by = 'time') %>%
     left_join(evap_data, by = 'time') %>%
@@ -123,7 +144,7 @@ run_glm3_model <- function(sim_dir, nml_obj, model_config, export_fl_template) {
         },
         error = function(e) {
           if (grepl(e$message, 'need at least two non-NA values to interpolate')) {
-            extraction_error <- 'NA values'
+            extraction_error <- 'NA temperature values'
           } else {
             extraction_error <- e$message
           }

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -22,6 +22,11 @@ extract_glm_output <- function(nc_filepath, nml_obj, export_fl) {
   ice_data <- glmtools::get_var(nc_filepath, var_name = 'hice') %>%
     mutate(ice = hice > 0, time = as.Date(lubridate::ceiling_date(DateTime, ' days'))) %>%
     select(-DateTime)
+  # check if max ice thickness exceeds lake depth
+  max_hice <- max(ice_data$hice)
+  if (max_hice > lake_depth) {
+    stop('Maximum hice value exceeds lake depth')
+  }
   all_results <- temp_data %>%
     left_join(ice_data, by = 'time') %>%
     left_join(evap_data, by = 'time') %>%


### PR DESCRIPTION
Add a quick check within `extract_glm_output()` function to check if the # of layers == 1, and, if so, if ice thickness exceeds lake depth. If # layers == 1 at any point during the simulation, this will return an error message, triggering the error function of the `tryCatch()` within `run_glm3_model()` and setting `glm_success` to `FALSE` for that simulation.

This has been tested locally and on Tallgrass. I tested with 14 lakes, 9 of which were known to have failed GCM runs previously, and the results were as expected. This was the set of unique extraction errors:
```r
> p2_gcm_glm_uncalibrated_runs %>% filter(glm_success==FALSE) %>% pull(extraction_error) %>% unique()
[1] "Number of layers drops to 1"
[2] "Number of layers drops to 1, Maximum hice value exceeds lake depth"
[3] "NA temperature values"
[4] NA
> length(unique(p2_gcm_glm_uncalibrated_runs %>% filter(glm_success==FALSE) %>% pull(site_id)))
[1] 9
> length(unique(p2_gcm_glm_uncalibrated_runs %>% group_by(site_id) %>% filter(all(glm_success)) %>% pull(site_id)))
[1] 5
```