### PR TITLE
Add model evaluation for NLDAS bottom predictions

### DIFF
--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -52,109 +52,149 @@ p5 <- list(
              },
              format = 'file'),
   
+  # Pull out lake depth for each evaluation site
+  tar_target(
+    p5_nldas_depths,
+    purrr::map_df(p5_eval_sites, function(site_id) {
+      site_nml <- p1_nldas_nml_list_subset[[site_id]]
+      tibble(
+        site_id = site_id,
+        lake_depth = site_nml$lake_depth
+      )
+    })
+  ),
+  
   # Prep matched preds for evaluation
   # Add pred_diff column (pred - obs)
   # Set up variables for which bias/accuracy will be calculated
   # Add fields for year, depth_class, doy, doy_bin, season, temp_bin
   tar_target(p5_nldas_pred_obs_eval,
-             prep_data_for_eval(p5_nldas_pred_obs, surface_cutoff_depth = 1, middle_cutoff_depth = 5,
-                                doy_bin_size = 5, temp_bin_size = 2)),
+             prep_data_for_eval(p5_nldas_pred_obs, p5_nldas_depths, surface_max_depth = 1, 
+                                bottom_depth_factor = 0.85, doy_bin_size = 5, temp_bin_size = 2)),
   
-  # Filter to only surface pred-obs
-  tar_target(p5_nldas_pred_obs_eval_surface,
-             filter(p5_nldas_pred_obs_eval, depth_class=='surface')),
+  # Filter evaluation pred-obs to surface and bottom predictions and set up for group mapping
+  tar_target(p5_nldas_pred_obs_eval_groups,
+             p5_nldas_pred_obs_eval %>%
+               filter(depth_class %in% c('surface','bottom')) %>%
+               group_by(depth_class) %>%
+               tar_group(),
+             iteration = "group"),
   
   ###### Assess model bias ######
   
   # Bias through time - year
-  tar_target(p5_nldas_surface_bias_year,
-             calc_bias(p5_nldas_pred_obs_eval_surface, grouping_var = 'year')),
+  tar_target(p5_nldas_bias_year,
+             calc_bias(p5_nldas_pred_obs_eval_groups, grouping_var = 'year',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   # Bias through time - doy
-  tar_target(p5_nldas_surface_bias_doy,
-             calc_bias(p5_nldas_pred_obs_eval_surface, grouping_var = 'doy_bin')),
+  tar_target(p5_nldas_bias_doy,
+             calc_bias(p5_nldas_pred_obs_eval_groups, grouping_var = 'doy_bin',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   # Bias by season
-  tar_target(p5_nldas_surface_bias_season,
-             calc_bias(p5_nldas_pred_obs_eval_surface, grouping_var = 'season')),
+  tar_target(p5_nldas_bias_season,
+             calc_bias(p5_nldas_pred_obs_eval_groups, grouping_var = 'season',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
 
   # Bias for specific temperature ranges
-  tar_target(p5_nldas_surface_bias_temp,
-             calc_bias(p5_nldas_pred_obs_eval_surface, grouping_var = 'temp_bin')),
+  tar_target(p5_nldas_bias_temp,
+             calc_bias(p5_nldas_pred_obs_eval_groups, grouping_var = 'temp_bin',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   ## Plots
   # Bar plot of bias through time, by  year
-  tar_target(p5_nldas_surface_bias_year_png,
-             plot_evaluation_barplot(p5_nldas_surface_bias_year, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'year', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_bias_year.png'),
+  tar_target(p5_nldas_bias_year_png,
+             plot_evaluation_barplot(p5_nldas_bias_year, driver= 'NLDAS', 
+                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'year', 
+                          faceting_variable = 'depth_class',
+                          outfile = '5_evaluate/out/nldas_bias_year.png'),
              format = 'file'),
   
   # Bar plot of bias through time, by doy
-  tar_target(p5_nldas_surface_bias_doy_png,
-             plot_evaluation_barplot(p5_nldas_surface_bias_doy, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'doy_bin', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_bias_doy.png'),
+  tar_target(p5_nldas_bias_doy_png,
+             plot_evaluation_barplot(p5_nldas_bias_doy, driver= 'NLDAS', 
+                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'doy_bin', 
+                          faceting_variable = 'depth_class',
+                          outfile = '5_evaluate/out/nldas_bias_doy.png'),
              format = 'file'),
   
   # Bar plot of bias by season
-  tar_target(p5_nldas_surface_bias_season_png,
-             plot_evaluation_barplot(p5_nldas_surface_bias_season, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'season', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_bias_season.png'),
+  tar_target(p5_nldas_bias_season_png,
+             plot_evaluation_barplot(p5_nldas_bias_season, driver= 'NLDAS', 
+                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'season', 
+                          faceting_variable = 'depth_class',
+                          outfile = '5_evaluate/out/nldas_bias_season.png'),
              format = 'file'),
   
   # Bar plot of bias for 2-degree temperature bins
-  tar_target(p5_nldas_surface_bias_temp_png,
-             plot_evaluation_barplot(p5_nldas_surface_bias_temp, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'temp_bin', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_bias_temp.png'),
+  tar_target(p5_nldas_bias_temp_png,
+             plot_evaluation_barplot(p5_nldas_bias_temp, driver= 'NLDAS', 
+                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'temp_bin', 
+                          faceting_variable = 'depth_class',
+                          outfile = '5_evaluate/out/nldas_bias_temp.png'),
              format = 'file'),
   
   ###### Assess model accuracy ######
   
   # # Accuracy through time - year
-  tar_target(p5_nldas_surface_accuracy_year,
-             calc_rmse(p5_nldas_pred_obs_eval_surface, grouping_var = 'year')),
+  tar_target(p5_nldas_accuracy_year,
+             calc_rmse(p5_nldas_pred_obs_eval_groups, grouping_var = 'year',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   # Accuracy through time - doy
-  tar_target(p5_nldas_surface_accuracy_doy,
-             calc_rmse(p5_nldas_pred_obs_eval_surface, grouping_var = 'doy_bin')),
+  tar_target(p5_nldas_accuracy_doy,
+             calc_rmse(p5_nldas_pred_obs_eval_groups, grouping_var = 'doy_bin',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   # Accuracy by season
-  tar_target(p5_nldas_surface_accuracy_season,
-             calc_rmse(p5_nldas_pred_obs_eval_surface, grouping_var = 'season')),
+  tar_target(p5_nldas_accuracy_season,
+             calc_rmse(p5_nldas_pred_obs_eval_groups, grouping_var = 'season',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   # Accuracy for specific temperature ranges
-  tar_target(p5_nldas_surface_accuracy_temp,
-             calc_rmse(p5_nldas_pred_obs_eval_surface, grouping_var = 'temp_bin')),
+  tar_target(p5_nldas_accuracy_temp,
+             calc_rmse(p5_nldas_pred_obs_eval_groups, grouping_var = 'temp_bin',
+                       depth_class = unique(p5_nldas_pred_obs_eval_groups$depth_class)),
+             pattern = map(p5_nldas_pred_obs_eval_groups)),
   
   ## Plots
   # Bar plot of accuracy through time, by  year
-  tar_target(p5_nldas_surface_accuracy_year_png,
-             plot_evaluation_barplot(p5_nldas_surface_accuracy_year, driver= 'NLDAS', 
-                          y_var = 'rmse', y_label = 'rmse', x_var = 'year', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_accuracy_year.png'),
+  tar_target(p5_nldas_accuracy_year_png,
+             plot_evaluation_barplot(p5_nldas_accuracy_year, driver= 'NLDAS', 
+                                     y_var = 'rmse', y_label = 'rmse', x_var = 'year', 
+                                     faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_accuracy_year.png'),
              format = 'file'),
   
   # Bar plot of accuracy through time, by doy
-  tar_target(p5_nldas_surface_accuracy_doy_png,
-             plot_evaluation_barplot(p5_nldas_surface_accuracy_doy, driver= 'NLDAS', 
-                          y_var = 'rmse', y_label = 'rmse', x_var = 'doy_bin', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_accuracy_doy.png'),
+  tar_target(p5_nldas_accuracy_doy_png,
+             plot_evaluation_barplot(p5_nldas_accuracy_doy, driver= 'NLDAS', 
+                                     y_var = 'rmse', y_label = 'rmse', x_var = 'doy_bin', 
+                                     faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_accuracy_doy.png'),
              format = 'file'),
   
   # Bar plot of accuracy by season
-  tar_target(p5_nldas_surface_accuracy_season_png,
-             plot_evaluation_barplot(p5_nldas_surface_accuracy_season, driver= 'NLDAS', 
-                          y_var = 'rmse', y_label = 'rmse', x_var = 'season', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_accuracy_season.png'),
+  tar_target(p5_nldas_accuracy_season_png,
+             plot_evaluation_barplot(p5_nldas_accuracy_season, driver= 'NLDAS', 
+                                     y_var = 'rmse', y_label = 'rmse', x_var = 'season', 
+                                     faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_accuracy_season.png'),
              format = 'file'),
   
   # Bar plot of accuracy for 2-degree temperature bins
-  tar_target(p5_nldas_surface_accuracy_temp_png,
-             plot_evaluation_barplot(p5_nldas_surface_accuracy_temp, driver= 'NLDAS', 
-                          y_var = 'rmse', y_label = 'rmse', x_var = 'temp_bin', depth_class='surface',
-                          outfile = '5_evaluate/out/nldas_surface_accuracy_temp.png'),
+  tar_target(p5_nldas_accuracy_temp_png,
+             plot_evaluation_barplot(p5_nldas_accuracy_temp, driver= 'NLDAS', 
+                                     y_var = 'rmse', y_label = 'rmse', x_var = 'temp_bin', 
+                                     faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_accuracy_temp.png'),
              format = 'file')
 )

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -109,34 +109,34 @@ p5 <- list(
   ## Plots
   # Bar plot of bias through time, by  year
   tar_target(p5_nldas_bias_year_png,
-             plot_evaluation_barplot(p5_nldas_bias_year, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'year', 
-                          faceting_variable = 'depth_class',
-                          outfile = '5_evaluate/out/nldas_bias_year.png'),
+             plot_evaluation_barplot(p5_nldas_bias_year, num_eval_sites = length(p5_eval_sites), 
+                                     driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
+                                     x_var = 'year', faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_bias_year.png'),
              format = 'file'),
   
   # Bar plot of bias through time, by doy
   tar_target(p5_nldas_bias_doy_png,
-             plot_evaluation_barplot(p5_nldas_bias_doy, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'doy_bin', 
-                          faceting_variable = 'depth_class',
-                          outfile = '5_evaluate/out/nldas_bias_doy.png'),
+             plot_evaluation_barplot(p5_nldas_bias_doy,  num_eval_sites = length(p5_eval_sites), 
+                                     driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
+                                     x_var = 'doy_bin', faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_bias_doy.png'),
              format = 'file'),
   
   # Bar plot of bias by season
   tar_target(p5_nldas_bias_season_png,
-             plot_evaluation_barplot(p5_nldas_bias_season, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'season', 
-                          faceting_variable = 'depth_class',
-                          outfile = '5_evaluate/out/nldas_bias_season.png'),
+             plot_evaluation_barplot(p5_nldas_bias_season, num_eval_sites = length(p5_eval_sites), 
+                                     driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
+                                     x_var = 'season', faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_bias_season.png'),
              format = 'file'),
   
   # Bar plot of bias for 2-degree temperature bins
   tar_target(p5_nldas_bias_temp_png,
-             plot_evaluation_barplot(p5_nldas_bias_temp, driver= 'NLDAS', 
-                          y_var = 'bias', y_label = 'predicted - observed', x_var = 'temp_bin', 
-                          faceting_variable = 'depth_class',
-                          outfile = '5_evaluate/out/nldas_bias_temp.png'),
+             plot_evaluation_barplot(p5_nldas_bias_temp, num_eval_sites = length(p5_eval_sites),
+                                     driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
+                                     x_var = 'temp_bin', faceting_variable = 'depth_class',
+                                     outfile = '5_evaluate/out/nldas_bias_temp.png'),
              format = 'file'),
   
   ###### Assess model accuracy ######
@@ -168,33 +168,33 @@ p5 <- list(
   ## Plots
   # Bar plot of accuracy through time, by  year
   tar_target(p5_nldas_accuracy_year_png,
-             plot_evaluation_barplot(p5_nldas_accuracy_year, driver= 'NLDAS', 
-                                     y_var = 'rmse', y_label = 'rmse', x_var = 'year', 
-                                     faceting_variable = 'depth_class',
+             plot_evaluation_barplot(p5_nldas_accuracy_year, num_eval_sites = length(p5_eval_sites),
+                                     driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
+                                     x_var = 'year', faceting_variable = 'depth_class',
                                      outfile = '5_evaluate/out/nldas_accuracy_year.png'),
              format = 'file'),
   
   # Bar plot of accuracy through time, by doy
   tar_target(p5_nldas_accuracy_doy_png,
-             plot_evaluation_barplot(p5_nldas_accuracy_doy, driver= 'NLDAS', 
-                                     y_var = 'rmse', y_label = 'rmse', x_var = 'doy_bin', 
-                                     faceting_variable = 'depth_class',
+             plot_evaluation_barplot(p5_nldas_accuracy_doy, num_eval_sites = length(p5_eval_sites),
+                                     driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
+                                     x_var = 'doy_bin', faceting_variable = 'depth_class',
                                      outfile = '5_evaluate/out/nldas_accuracy_doy.png'),
              format = 'file'),
   
   # Bar plot of accuracy by season
   tar_target(p5_nldas_accuracy_season_png,
-             plot_evaluation_barplot(p5_nldas_accuracy_season, driver= 'NLDAS', 
-                                     y_var = 'rmse', y_label = 'rmse', x_var = 'season', 
-                                     faceting_variable = 'depth_class',
+             plot_evaluation_barplot(p5_nldas_accuracy_season, num_eval_sites = length(p5_eval_sites),
+                                     driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
+                                     x_var = 'season', faceting_variable = 'depth_class',
                                      outfile = '5_evaluate/out/nldas_accuracy_season.png'),
              format = 'file'),
   
   # Bar plot of accuracy for 2-degree temperature bins
   tar_target(p5_nldas_accuracy_temp_png,
-             plot_evaluation_barplot(p5_nldas_accuracy_temp, driver= 'NLDAS', 
-                                     y_var = 'rmse', y_label = 'rmse', x_var = 'temp_bin', 
-                                     faceting_variable = 'depth_class',
+             plot_evaluation_barplot(p5_nldas_accuracy_temp, num_eval_sites = length(p5_eval_sites),
+                                     driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
+                                     x_var = 'temp_bin', faceting_variable = 'depth_class',
                                      outfile = '5_evaluate/out/nldas_accuracy_temp.png'),
              format = 'file')
 )

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -9,8 +9,13 @@ p5 <- list(
   ###### Prep predictions and observations ######
   
   # Get vector of site_ids for which we have NLDAS output
+  # For now, evaluation only predictions for lakes within CASC states
+  tar_target(p5_CASC_states,
+             c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
   tar_target(p5_nldas_export_site_ids,
              p3_nldas_glm_uncalibrated_output_feather_tibble %>%
+               filter(state %in% p5_CASC_states) %>%
+               arrange(site_id) %>%
                pull(site_id)),
   
   # Prep site observations

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -9,7 +9,7 @@ p5 <- list(
   ###### Prep predictions and observations ######
   
   # Get vector of site_ids for which we have NLDAS output
-  # For now, evaluation only predictions for lakes within CASC states
+  # For now, evaluate only predictions for lakes within CASC states
   tar_target(p5_CASC_states,
              c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
   tar_target(p5_nldas_export_site_ids,

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -24,10 +24,6 @@ p5 <- list(
   tar_target(p5_obs_for_eval,
              get_eval_obs(p1_obs_feather, p5_nldas_export_site_ids, p1_nldas_dates$driver_start_date, 
                           p1_nldas_dates$driver_end_date, min_obs_dates = 10)),
-  
-  # Get vector of evaluation sites, based on availability of observations
-  tar_target(p5_eval_sites,
-             p5_obs_for_eval %>% pull(site_id) %>% unique()),
 
   # Group filtered obs by site, set up tar_group()
   tar_target(p5_obs_for_eval_groups,
@@ -51,6 +47,10 @@ p5 <- list(
                return(outfile)
              },
              format = 'file'),
+  
+  # Get vector of evaluation sites, based on matched pred-obs
+  tar_target(p5_eval_sites,
+             p5_nldas_pred_obs %>% pull(site_id) %>% unique()),
   
   # Pull out lake depth for each evaluation site
   tar_target(

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -120,7 +120,8 @@ p5 <- list(
              plot_evaluation_barplot(p5_nldas_bias_doy,  num_eval_sites = length(p5_eval_sites), 
                                      driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
                                      x_var = 'doy_bin', faceting_variable = 'depth_class',
-                                     outfile = '5_evaluate/out/nldas_bias_doy.png'),
+                                     outfile = '5_evaluate/out/nldas_bias_doy.png',
+                                     plot_width = 12),
              format = 'file'),
   
   # Bar plot of bias by season
@@ -128,7 +129,8 @@ p5 <- list(
              plot_evaluation_barplot(p5_nldas_bias_season, num_eval_sites = length(p5_eval_sites), 
                                      driver= 'NLDAS', y_var = 'bias', y_label = 'predicted - observed', 
                                      x_var = 'season', faceting_variable = 'depth_class',
-                                     outfile = '5_evaluate/out/nldas_bias_season.png'),
+                                     outfile = '5_evaluate/out/nldas_bias_season.png',
+                                     plot_width = 6),
              format = 'file'),
   
   # Bar plot of bias for 2-degree temperature bins
@@ -179,7 +181,8 @@ p5 <- list(
              plot_evaluation_barplot(p5_nldas_accuracy_doy, num_eval_sites = length(p5_eval_sites),
                                      driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
                                      x_var = 'doy_bin', faceting_variable = 'depth_class',
-                                     outfile = '5_evaluate/out/nldas_accuracy_doy.png'),
+                                     outfile = '5_evaluate/out/nldas_accuracy_doy.png',
+                                     plot_width = 12),
              format = 'file'),
   
   # Bar plot of accuracy by season
@@ -187,7 +190,8 @@ p5 <- list(
              plot_evaluation_barplot(p5_nldas_accuracy_season, num_eval_sites = length(p5_eval_sites),
                                      driver= 'NLDAS', y_var = 'rmse', y_label = 'rmse', 
                                      x_var = 'season', faceting_variable = 'depth_class',
-                                     outfile = '5_evaluate/out/nldas_accuracy_season.png'),
+                                     outfile = '5_evaluate/out/nldas_accuracy_season.png',
+                                     plot_width = 6),
              format = 'file'),
   
   # Bar plot of accuracy for 2-degree temperature bins

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -163,6 +163,7 @@ calc_rmse <- function(eval_pred_obs, grouping_var, depth_class) {
 #' specified x and y variables
 #' @param plot_df a tibble of the matched model predictions and observations,
 #' along with grouping variables for evaluation
+#' @param num_eval_sites The number of unique evaluation sites 
 #' @param driver the name of the driver used to generate the
 #' model predictions
 #' @param y_var the variable for the y-axis of the plot
@@ -171,11 +172,12 @@ calc_rmse <- function(eval_pred_obs, grouping_var, depth_class) {
 #' @faceting_variable variable to use for faceting the plot
 #' @param outfile The filepath for the exported png
 #' @return The filepath of the exported png 
-plot_evaluation_barplot <- function(plot_df, driver, y_var, y_label, x_var, faceting_variable, outfile) {
+plot_evaluation_barplot <- function(plot_df, num_eval_sites, driver, y_var, y_label, x_var, faceting_variable, outfile) {
   bar_plot <- plot_df %>%
     ggplot(aes(x = get(x_var), y = get(y_var))) +
     geom_col(fill='cadetblue3', color='cadetblue4') +
-    labs(title= sprintf("%s predictions: %s by %s", driver, y_var, x_var), 
+    labs(title = paste(sprintf("%s predictions: %s by %s", driver, y_var, x_var),
+                       sprintf("Total # of evaluation sites: %s", num_eval_sites), sep ='\n'), 
          x=sprintf("%s", x_var), 
          y=sprintf("%s (\u00b0C)", y_label)) +
     facet_wrap(~get(faceting_variable), nrow = 2) +

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -144,7 +144,7 @@ calc_bias <- function(eval_pred_obs, grouping_var, depth_class) {
 #' specified `grouping_var`
 #' @param eval_pred_obs a tibble of the matched model predictions and 
 #' observations, along with grouping variables for evaluation
-#' @param grouping_var the variable by which to group `pred-obs`
+#' @param grouping_var the variable by which to group `eval_pred_obs`
 #' before calculating the rmse
 #' @param depth_class the depth bin for the matched `eval_pred_obs`
 #' @return a tibble grouped by the grouping_var, with a column

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -71,7 +71,8 @@ match_pred_obs <- function(preds_file, eval_obs) {
       mutate(obs_1d, pred = NA)
     })
     return(interp_1d)
-  }))
+  })) %>%
+    filter(!is.na(pred)) # Filter out rows where there are no matching predictions for observed depths (e.g. observed depth exceeds predicted depth)
   
   return(pred_obs)
 }
@@ -79,12 +80,15 @@ match_pred_obs <- function(preds_file, eval_obs) {
 #' @title prep pred-obs data for evaluation
 #' @description add grouping variables to matched pred-obs for evaluation.
 #' @param pred_obs the tibble of matched observations and predictions
-#' @param surface_cutoff_depth maximum depth for which predictions are
+#' @param lake_depths tibble of lake depths for evluation sites
+#' @param surface_max_depth maximum depth for which predictions are
 #' considered to be in the 'surface' depth class. Currently this is set
 #' as a global value, and is not lake-specific
-#' @param middle_cutoff_depth maximum depth for which predictions are
-#' considered to be in the 'middle' depth class. Currently this is set
-#' as a global value, and is not lake-specific
+#' @param bottom_depth_factor a factor indicating the proportion
+#' of the water column considered to be *outside* of the 'bottom' depth 
+#' class. When multiplied by each lake's depth, the resulting value is the 
+#' minimum depth for which predictions for each lake are considered to be 
+#' in the 'bottom' depth class
 #' @param doy_bin_size # of days to include in each doy bin
 #' @param temp_bin_size # of degrees to include in each temperature bin
 #' @return a tibble of matched predictions and observations with the 
@@ -92,14 +96,15 @@ match_pred_obs <- function(preds_file, eval_obs) {
 #' depth_class (surface, middle, or bottom), year, doy, doy_bin (size 
 #' set by `doy_bin_size`), and season of each pred-obs pair, and the 
 #' temperature bin (size set by `temp_bin_size`) into which each observation falls 
-prep_data_for_eval <- function(pred_obs, surface_cutoff_depth, middle_cutoff_depth, doy_bin_size, temp_bin_size) {
+prep_data_for_eval <- function(pred_obs, lake_depths, surface_max_depth, bottom_depth_factor, doy_bin_size, temp_bin_size) {
   
   eval_pred_obs <- pred_obs %>%
+    left_join(lake_depths, by='site_id') %>%
     mutate(pred_diff = pred - obs,
            depth_class = case_when(
-             depth <= surface_cutoff_depth ~ 'surface',
-             depth > surface_cutoff_depth & depth <= middle_cutoff_depth ~ 'middle',
-             TRUE ~ 'bottom'
+             depth <= surface_max_depth ~ 'surface',
+             depth >= (bottom_depth_factor * lake_depth) ~ 'bottom',
+             TRUE ~ 'middle'
            ),
            year = year(time),
            doy = yday(time),
@@ -120,15 +125,17 @@ prep_data_for_eval <- function(pred_obs, surface_cutoff_depth, middle_cutoff_dep
 #' specified `grouping_var`
 #' @param eval_pred_obs a tibble of the matched model predictions and 
 #' observations, along with grouping variables for evaluation
-#' @param grouping_var the variable by which to group `pred-obs`
+#' @param grouping_var the variable by which to group `eval_pred_obs`
 #' before calculating the bias
+#' @param depth_class the depth bin for the matched `eval_pred_obs`
 #' @return
-calc_bias <- function(eval_pred_obs, grouping_var) {
+calc_bias <- function(eval_pred_obs, grouping_var, depth_class) {
   eval_pred_obs %>%
     group_by(!!sym(grouping_var)) %>%
     summarize(bias = median(pred_diff, na.rm=TRUE),
               n_dates = n(),
-              n_sites = length(unique(site_id)))
+              n_sites = length(unique(site_id))) %>%
+    mutate(depth_class = depth_class, .before=1)
 }
 
 #' @title Calculate rmse
@@ -138,14 +145,16 @@ calc_bias <- function(eval_pred_obs, grouping_var) {
 #' observations, along with grouping variables for evaluation
 #' @param grouping_var the variable by which to group `pred-obs`
 #' before calculating the rmse
+#' @param depth_class the depth bin for the matched `eval_pred_obs`
 #' @return a tibble grouped by the grouping_var, with a column
 #' for rmse
-calc_rmse <- function(eval_pred_obs, grouping_var) {
+calc_rmse <- function(eval_pred_obs, grouping_var, depth_class) {
   eval_pred_obs %>%
     group_by(!!sym(grouping_var)) %>%
     summarize(rmse = sqrt(mean((pred_diff)^2, na.rm=TRUE)),
               n_dates = n(),
-              n_sites = length(unique(site_id)))
+              n_sites = length(unique(site_id))) %>%
+    mutate(depth_class = depth_class, .before=1)
 }
 
 #' @title Plot evaluation metrics as a bar plot
@@ -158,17 +167,17 @@ calc_rmse <- function(eval_pred_obs, grouping_var) {
 #' @param y_var the variable for the y-axis of the plot
 #' @param y_label the label for the y-axis of the plot
 #' @param x_var the variable for the x-axis of the plot
-#' @param depth_class depth_class of the pred-obs (surface, middle,
-#' or bottom) that are being plotted.
+#' @faceting_variable variable to use for faceting the plot
 #' @param outfile The filepath for the exported png
 #' @return The filepath of the exported png 
-plot_evaluation_barplot <- function(plot_df, driver, y_var, y_label, x_var, depth_class, outfile) {
+plot_evaluation_barplot <- function(plot_df, driver, y_var, y_label, x_var, faceting_variable, outfile) {
   bar_plot <- plot_df %>%
     ggplot(aes(x = get(x_var), y = get(y_var))) +
     geom_col(fill='cadetblue3', color='cadetblue4') +
-    labs(title= sprintf("%s %s predictions: %s by %s", driver, depth_class, y_var, x_var), 
+    labs(title= sprintf("%s predictions: %s by %s", driver, y_var, x_var), 
          x=sprintf("%s", x_var), 
          y=sprintf("%s (\u00b0C)", y_label)) +
+    facet_wrap(~get(faceting_variable)) +
     theme_bw()
   
   ggsave(filename=outfile, plot=bar_plot, dpi=300, width=10, height=6)

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -131,6 +131,10 @@ prep_data_for_eval <- function(pred_obs, lake_depths, surface_max_depth, bottom_
 #' @param depth_class the depth bin for the matched `eval_pred_obs`
 #' @return
 calc_bias <- function(eval_pred_obs, grouping_var, depth_class) {
+  # confirm that only matched pred-obs for a single depth class were provided
+  stopifnot(length(depth_class) == 1)
+  
+  # calculate bias
   eval_pred_obs %>%
     group_by(!!sym(grouping_var)) %>%
     summarize(bias = median(pred_diff, na.rm=TRUE),
@@ -150,6 +154,10 @@ calc_bias <- function(eval_pred_obs, grouping_var, depth_class) {
 #' @return a tibble grouped by the grouping_var, with a column
 #' for rmse
 calc_rmse <- function(eval_pred_obs, grouping_var, depth_class) {
+  # confirm that only matched pred-obs for a single depth class were provided
+  stopifnot(length(depth_class) == 1)
+  
+  # calculate rmse
   eval_pred_obs %>%
     group_by(!!sym(grouping_var)) %>%
     summarize(rmse = sqrt(mean((pred_diff)^2, na.rm=TRUE)),

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -180,7 +180,8 @@ calc_rmse <- function(eval_pred_obs, grouping_var, depth_class) {
 #' @faceting_variable variable to use for faceting the plot
 #' @param outfile The filepath for the exported png
 #' @return The filepath of the exported png 
-plot_evaluation_barplot <- function(plot_df, num_eval_sites, driver, y_var, y_label, x_var, faceting_variable, outfile) {
+plot_evaluation_barplot <- function(plot_df, num_eval_sites, driver, y_var, y_label, x_var, faceting_variable, 
+                                    outfile, plot_dpi = 300, plot_width = 10, plot_height = 8) {
   bar_plot <- plot_df %>%
     ggplot(aes(x = get(x_var), y = get(y_var))) +
     geom_col(fill='cadetblue3', color='cadetblue4') +
@@ -191,6 +192,6 @@ plot_evaluation_barplot <- function(plot_df, num_eval_sites, driver, y_var, y_la
     facet_wrap(~get(faceting_variable), nrow = 2) +
     theme_bw()
   
-  ggsave(filename=outfile, plot=bar_plot, dpi=300, width=10, height=8)
+  ggsave(filename=outfile, plot=bar_plot, dpi=plot_dpi, width=plot_width, height=plot_height)
   return(outfile)
 }

--- a/5_evaluate/src/eval_utility_fxns.R
+++ b/5_evaluate/src/eval_utility_fxns.R
@@ -106,6 +106,7 @@ prep_data_for_eval <- function(pred_obs, lake_depths, surface_max_depth, bottom_
              depth >= (bottom_depth_factor * lake_depth) ~ 'bottom',
              TRUE ~ 'middle'
            ),
+           depth_class = factor(depth_class,levels=c('surface','middle','bottom')),
            year = year(time),
            doy = yday(time),
            doy_bin = doy_bin_size*ceiling(doy/doy_bin_size),
@@ -120,7 +121,7 @@ prep_data_for_eval <- function(pred_obs, lake_depths, surface_max_depth, bottom_
   return(eval_pred_obs)
 }
 
-#' @title Calcuate bias
+#' @title Calculate bias
 #' @description Calculate the bias of model predictions over a 
 #' specified `grouping_var`
 #' @param eval_pred_obs a tibble of the matched model predictions and 
@@ -177,9 +178,9 @@ plot_evaluation_barplot <- function(plot_df, driver, y_var, y_label, x_var, face
     labs(title= sprintf("%s predictions: %s by %s", driver, y_var, x_var), 
          x=sprintf("%s", x_var), 
          y=sprintf("%s (\u00b0C)", y_label)) +
-    facet_wrap(~get(faceting_variable)) +
+    facet_wrap(~get(faceting_variable), nrow = 2) +
     theme_bw()
   
-  ggsave(filename=outfile, plot=bar_plot, dpi=300, width=10, height=6)
+  ggsave(filename=outfile, plot=bar_plot, dpi=300, width=10, height=8)
   return(outfile)
 }


### PR DESCRIPTION
~I'm marking this PR as DRAFT while I test this code on Tallgrass for [the latest full footprint NLDAS run](https://github.com/USGS-R/lake-temperature-process-models/discussions/57#discussioncomment-2867189) (it has already been tested locally) -- I'm leaving it running overnight.~ Code ran successfully

@jread-usgs and @lindsayplatt - I've separated my review request into two sections ~and will request a review once this PR is no longer DRAFT and I've added links to the plots.~

NLDAS model evaluation plots for surface and bottom predictions from the [6/1 full run](https://github.com/USGS-R/lake-temperature-process-models/discussions/57#discussioncomment-2867189) are [HERE](https://doimspp.sharepoint.com/:f:/r/sites/IIDDStaff/Shared%20Documents/Project%20-%20Modeling%20Lakes/GLM/lake-temperature-process-models/NLDAS_evaluation_plots/FullFootprint_20220601?csf=1&web=1&e=dWdfQa). Here's an example plot:
![nldas_accuracy_doy](https://user-images.githubusercontent.com/54007288/171904791-f0041a53-6bb5-47b5-8f4e-69b0ecd6be8f.png)

_________

@jread-usgs - I'd like you to review the meat of this PR, which is the addition of model evaluation for predictions at depth

This PR modifies the `5_evaluate` phase to add evaluation of predictions in the 'bottom' depth_class. Previously all depth classes were set globally. This PR retains the global definition of surface predictions (all predictions at depths <= 1 meter), but shifts to a lake-specific definition of bottom predictions -- classifying predictions as 'bottom' predictions if they fall at a depth >= a `bottom_depth_factor` * `lake_depth`. Currently that `bottom_depth_factor` is 0.85, so predictions at all depths >= 85% of `lake_depth` are classified as 'bottom' predictions for each lake.

I noticed while looking at matched pred-obs for the 'bottom' depth_class that there were instances where the matched `pred` value was NA for 1+ of the deepest observations on a given date, I believe b/c observed depth exceeded predicted depth. To drop those NAs from the matched pred-obs, I added a step in the matching function to [filter out rows where there are no matching predictions for observed depths](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/NLDAS_depth_eval/5_evaluate/src/eval_utility_fxns.R#L75). I then define `p5_eval_sites` based on the unique site_ids in that matched set of pred-obs.

This PR also makes some additional requested edits to the evaluation code:
* Restricts evaluation to lakes within CASC states
* Adds the total # of evaluation sites as a subtitle on plots

-----------------------------

@lindsayplatt I'd like you to focus your review on these changes to the `targets` approach:

To reduce the total # of added targets I switched to a [eval target grouped by depth class](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/NLDAS_depth_eval/5_evaluate.R#L75-L81). This lets me generate the accuracy and bias metrics for both surface and bottom depth classes by [mapping over the grouped target](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/NLDAS_depth_eval/5_evaluate.R#L89). This also allows me to include evaluation of both surface and bottom predictions in a single faceted plot.

-----------------------------

