### PR TITLE
Group GCM runs by site_id to reduce # branches

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -19,7 +19,7 @@ p1 <- list(
   tar_target(p1_lake_cell_tile_xwalk_df, 
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
                filter(site_id %in% p1_nml_site_ids) %>%
-               arrange(site_id)), 
+               arrange(site_id)),
   
   ##### Define vector of site ids and subset nml list #####
   # Pull vector of site ids
@@ -65,9 +65,24 @@ p1 <- list(
              format = 'file',
              pattern = map(p1_gcm_ncs, p1_gcm_names)),
 
+  # Set up grouping for model runs
+  tar_target(p1_gcm_group_length,
+             # number of model runs to execute per tar_group
+             length(p1_gcm_names)*nrow(p1_gcm_dates)),
   # Build GCM model config
-  tar_target(p1_gcm_model_config,
-             build_gcm_model_config(p1_gcm_csvs, p1_lake_cell_tile_xwalk_df, p1_gcm_names, p1_gcm_dates)),
+  tar_target(p1_gcm_model_config_groups,
+             build_gcm_model_config(p1_gcm_csvs, p1_lake_cell_tile_xwalk_df, p1_gcm_names, p1_gcm_dates) %>%
+               # Grouping to reduce number of target branches
+               # Currently p1_gcm_group_length = # GCMs * 3 time periods = 18, so there is one group per site
+               # This is the easiest batching to set up given the mapping to build `p2_gcm_glm_uncalibrated_runs`
+               mutate(n_groups = ceiling(n() / p1_gcm_group_length),
+                      seq = seq_len(n()),
+                      target_group = ntile(seq, n_groups)) %>%
+               select(-seq, -n_groups) %>%
+               group_by(target_group) %>%
+               tar_group(),
+             iteration = "group"
+  ),
   
   # Set up list of nml objects, with NULL for meteo_fl, and custom depth parameters
   # Transform a single file of all lakes to a single list of all lakes

--- a/1_prep.R
+++ b/1_prep.R
@@ -79,21 +79,11 @@ p1 <- list(
              format = 'file',
              pattern = map(p1_gcm_ncs, p1_gcm_names)),
 
-  # Set up grouping for model runs
-  tar_target(p1_gcm_group_length,
-             # number of model runs to execute per tar_group
-             length(p1_gcm_names)*nrow(p1_gcm_dates)),
-  # Build GCM model config
+  # Build GCM model config, grouped by site_id
   tar_target(p1_gcm_model_config_groups,
              build_gcm_model_config(p1_gcm_csvs, p1_lake_cell_tile_xwalk_df, p1_gcm_names, p1_gcm_dates) %>%
-               # Grouping to reduce number of target branches
-               # Currently p1_gcm_group_length = # GCMs * 3 time periods = 18, so there is one group per site
-               # This is the easiest batching to set up given the mapping to build `p2_gcm_glm_uncalibrated_runs`
-               mutate(n_groups = ceiling(n() / p1_gcm_group_length),
-                      seq = seq_len(n()),
-                      target_group = ntile(seq, n_groups)) %>%
-               select(-seq, -n_groups) %>%
-               group_by(target_group) %>%
+               # Grouping by site_id to reduce number of target branches downstream
+               group_by(site_id) %>%
                tar_group(),
              iteration = "group"
   ),

--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -45,8 +45,8 @@ build_gcm_model_config <- function(gcm_csvs, lake_cell_tile_xwalk, gcm_names, gc
     nesting(gcm_dates)) %>%
     arrange(site_id) %>%
     left_join(meteo_branches, by=c('driver', 'data_cell_no', 'time_period')) %>%
-    select(-data_cell_no) %>%
-    rowwise()
+    select(-data_cell_no)
+  
   return(model_config)
 }
 

--- a/2_run.R
+++ b/2_run.R
@@ -27,9 +27,9 @@ p2 <- list(
     pattern = map(p1_gcm_model_config_groups, p1_gcm_nml_objects)), # W/ all runs for each lake in 1 config group, can map over nml objects w/o cross(), as is same length as # of config groups
   
   # For bundling of results in 3_extract
-  # Group model runs by lake id
   # Discard the glm diagnostics so they don't trigger rebuilds
   # even when the export_fl_hash is unchanged
+  # Group model runs by lake id
   # Filter to groups where all model runs were successful 
   # (if any failed, the group is filtered out)
   tar_target(
@@ -63,10 +63,11 @@ p2 <- list(
     pattern = map(p1_nldas_model_config, p1_nldas_nml_objects)),
   
   # For bundling of results by lake in 3_extract
-  # Group model runs by lake id
   # Discard the glm diagnostics so they don't trigger rebuilds
   # even when the export_fl_hash is unchanged
-  # Filter to successful model runs
+  # Group model runs by lake id
+  # Filter to groups where all model runs were successful 
+  # (if any failed, the group is filtered out)
   tar_target(
     p2_nldas_glm_uncalibrated_run_groups,
     p2_nldas_glm_uncalibrated_runs %>%

--- a/3_extract.R
+++ b/3_extract.R
@@ -9,8 +9,14 @@ p3 <- list(
   # saving only the temperature predictions for each depth and ice flags
   tar_target(
     p3_gcm_glm_uncalibrated_output_feathers,
-    write_glm_output(p2_gcm_glm_uncalibrated_run_groups,
-                     outfile_template='3_extract/out/GLM_%s_%s.feather'),
+    {
+      output_files <- p2_gcm_glm_uncalibrated_run_groups %>% # Already grouped by site_id
+        group_by(driver) %>% # Also group by driver (GCM) for creating export files
+        group_map(~ write_glm_output(.x, outfile_template='3_extract/out/GLM_%s_%s.feather'),
+                  .keep = TRUE) %>%
+        unlist()
+      return(output_files)
+    },
     format = 'file',
     pattern = map(p2_gcm_glm_uncalibrated_run_groups)),
   

--- a/4_visualize.R
+++ b/4_visualize.R
@@ -51,9 +51,9 @@ p4 <- list(
     format='file'),
   
   # Plots for each lake
-  # Subset p2_glm_uncalibrated_lake_groups to selected plotting site_ids
+  # Subset p2_glm_uncalibrated_run_groups to selected plotting site_ids
   tar_target(p4_subset_gcm_lake_groups,
-             p2_gcm_glm_uncalibrated_lake_groups %>%
+             p2_gcm_glm_uncalibrated_run_groups %>%
                filter(site_id %in% p4_plot_site_ids) %>%
                group_by(site_id) %>% 
                tar_group(),


### PR DESCRIPTION
Modify setup of GCM GLM runs so that instead of having 1 `targets` branch per model run (i.e., 18 `targets` branches per lake -- 6 GCMs * 3 time periods = 18), we have 1 `targets` branch per lake (with 18 _runs_ per branch). This reduces the number of `targets` branches by a factor of 18. This is the simplest approach to resolve #41 given the setup of the pipeline and the mapping used to build `p2_gcm_glm_uncalibrated_runs`. 

The extraction of model output is similarly adapted so that we now extract all output for a successfully modeled lake in a single `targets` branch, rather than having an individual `targets` branch for each lake-gcm combo. 

This PR also removes the `p2_gcm_glm_uncalibrated_lake_groups` target as it is no longer necessary.

This code has been tested both locally and on Tallgrass, for up to 1146 sites.