### PR TITLE
Expand GCM runs to full footprint

### DIFF
--- a/1_prep.R
+++ b/1_prep.R
@@ -25,7 +25,8 @@ p1 <- list(
                filter(site_id %in% p1_nml_site_ids) %>%
                arrange(site_id)),
 
-  # lake - GCM cell - GCM tile crosswalk
+  # lake - GCM cell - GCM tile crosswalk, assumed to only include lakes
+  # that are in the nml list (able to be modeled by GLM)
   # used to define site_ids for GCM runs
   # file copied from lake-temperature-model-prep repo '7_drivers_munge/out/lake_cell_tile_xwalk.csv'
   tar_target(p1_lake_cell_tile_xwalk_csv, '1_prep/in/lake_cell_tile_xwalk.csv', format = 'file'),

--- a/1_prep.R
+++ b/1_prep.R
@@ -25,14 +25,12 @@ p1 <- list(
                filter(site_id %in% p1_nml_site_ids) %>%
                arrange(site_id)),
 
-  # lake - GCM cell - GCM tile crosswalk, filtered to only those lakes
-  # that are in nml list (able to be modeled by GLM)
+  # lake - GCM cell - GCM tile crosswalk
   # used to define site_ids for GCM runs
   # file copied from lake-temperature-model-prep repo '7_drivers_munge/out/lake_cell_tile_xwalk.csv'
   tar_target(p1_lake_cell_tile_xwalk_csv, '1_prep/in/lake_cell_tile_xwalk.csv', format = 'file'),
   tar_target(p1_lake_cell_tile_xwalk_df, 
              readr::read_csv(p1_lake_cell_tile_xwalk_csv, col_types=cols()) %>%
-               filter(site_id %in% p1_nml_site_ids) %>%
                arrange(site_id)),
   
   ##### GCM model set up #####

--- a/5_evaluate.R
+++ b/5_evaluate.R
@@ -2,13 +2,20 @@ source('5_evaluate/src/eval_utility_fxns.R')
 source('4_visualize/src/plot_data_utility_fxns.R')
 
 p5 <- list(
+  # For now, evaluate only predictions for lakes within CASC states
+  tar_target(p5_CASC_states,
+             c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
+  
   ##### Evaluate GCM model output #####
   
   ###### Prep predictions and observations ######
   
   # Get vector of site_ids for which we have GCM output
+  # filtering to sites withing CASC states
   tar_target(p5_gcm_export_site_ids,
              p3_gcm_glm_uncalibrated_output_feather_tibble %>%
+               filter(state %in% p5_CASC_states) %>%
+               arrange(site_id) %>%
                pull(site_id) %>%
                unique()),
   
@@ -134,9 +141,7 @@ p5 <- list(
   ###### Prep predictions and observations ######
   
   # Get vector of site_ids for which we have NLDAS output
-  # For now, evaluate only predictions for lakes within CASC states
-  tar_target(p5_CASC_states,
-             c('ND','SD','IA','MI','IN','IL','WI','MN','MO','AR','OH')),
+  # filtering to sites within CASC states
   tar_target(p5_nldas_export_site_ids,
              p3_nldas_glm_uncalibrated_output_feather_tibble %>%
                filter(state %in% p5_CASC_states) %>%


### PR DESCRIPTION
These code changes allow for expansion of the GCM runs to the full model footprint.

Specific changes:
* Remove filtering to GLM-modelable lakes, since now completed [in `lake-temperature-model-prep`](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R#L60)
* Add a step to also restrict GCM evaluation to only sites within CASC states


To actually run for the full footprint, this requires manually transferring [these files](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/7_drivers_munge/out/7_GCM_driver_files.ind#L1-L7) updated by the expansion of the [ `lake-temperature-model-prep` `targets` sub-pipeline](https://github.com/USGS-R/lake-temperature-model-prep/blob/main/_targets.R) to the `'1_prep/in'` folder of this pipeline:
* `'1_prep/in/lake_cell_tile_xwalk.csv'`
* `'1_prep/in/GCM_{gcm name}.nc'` (6 netCDF files)