### PR TITLE
Drop mapping when building export file tibbles

### DIFF
--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -21,7 +21,7 @@ build_gcm_model_config <- function(gcm_csvs, lake_cell_tile_xwalk, gcm_names, gc
   gcm_name_list <- paste(gcm_names,collapse="|")
   gcm_time_period_list <- paste(gcm_dates$time_period,collapse="|")
   data_cell_no_list <- paste(unique(lake_cell_tile_xwalk$data_cell_no),collapse= "|")
-  # Build tibble of meteo files, branches, hashes, gcm name, cell_no, and time_period
+  # Build tibble of meteo files, hashes, driver (gcm name), cell_no, and time_period
   meteo_branches <- tibble(
     meteo_fl = gcm_csvs,
     meteo_fl_hash = tools::md5sum(gcm_csvs),

--- a/3_extract.R
+++ b/3_extract.R
@@ -26,9 +26,10 @@ p3 <- list(
   # and the cell_no and tile_no for that lake.
   tar_target(
     p3_gcm_glm_uncalibrated_output_feather_tibble,
-    generate_output_tibble(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers, 
-                           lake_xwalk = p1_lake_cell_tile_xwalk_df),
-    pattern = map(p2_gcm_glm_uncalibrated_run_groups, p3_gcm_glm_uncalibrated_output_feathers)
+    generate_output_tibble(p3_gcm_glm_uncalibrated_output_feathers,
+                           output_site_ids = unique(p2_gcm_glm_uncalibrated_run_groups$site_id),
+                           driver_names = unique(p2_gcm_glm_uncalibrated_run_groups$driver),
+                           lake_xwalk = p1_lake_cell_tile_xwalk_df)
   ),
   
   # Save summary of output files
@@ -83,9 +84,10 @@ p3 <- list(
   # site_id, driver (NLDAS), and the state the lake is in
   tar_target(
     p3_nldas_glm_uncalibrated_output_feather_tibble,
-    generate_output_tibble(p2_nldas_glm_uncalibrated_run_groups, p3_nldas_glm_uncalibrated_output_feathers, 
-                           lake_xwalk = p1_lake_to_state_xwalk_df),
-    pattern = map(p2_nldas_glm_uncalibrated_run_groups, p3_nldas_glm_uncalibrated_output_feathers)
+    generate_output_tibble(p3_nldas_glm_uncalibrated_output_feathers, 
+                           output_site_ids = unique(p2_nldas_glm_uncalibrated_run_groups$site_id),
+                           driver_names = unique(p2_nldas_glm_uncalibrated_run_groups$driver),
+                           lake_xwalk = p1_lake_to_state_xwalk_df)
   ),
   
   # Save summary of output files

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -1,4 +1,4 @@
-#' @title Combine output from GLM model runs
+#' @title Filter and write output from GLM model runs
 #' @description function to read in the raw output from successful
 #' GLM runs using GCM or NLDAS drivers, remove the ice thickness, 
 #' evaporation, and n_layers variables (leaving the temperature 
@@ -43,13 +43,16 @@ write_glm_output <- function(run_group, outfile_template) {
 #' driver, the state the lake is in, and, if the passed runs are
 #' GCM runs, the GCM spatial_cell_no, spatial_tile_no, data_cell_no, 
 #' and data_tile_no for that lake.
-#' @param run_group a single group of successful model runs. If the
-#' passed runs are GCM runs, this group includes all runs for a lake-gcm combo
-#' (nrows = 3). If the passed runs are NLDAS runs, this group includes all
-#' runs for a given lake (nrows = 1). The function maps over these groups.
-#' @param output_feather A single feather file name from the list of 
-#' output feather file names returned by `write_glm_output()`. 
+#' @param output_feathers The file names of the final output feather files
+#' returned by `write_glm_output()`, for all successfully modeled sites. If
+#' the passed runs are GCM runs, each site has 6 output feather files. If
+#' the passed runs are NLDAS runs, each site has 1 output feather file. 
 #' The function maps over these file names.
+#' @param output_site_ids vector of site_ids for which there are output
+#' feather files
+#' @param driver_names names of the driver(s) used to run the models. If
+#' the passed runs are GCM runs, this is a vector of the 6 GCM names. If the
+#' passed runs are NLDAS runs, this is 'NLDAS'
 #' @param lake_xwalk - If the passed runs are GCM runs, this xwalk is a 
 #' mapping of which lakes fall into which gcm cells and tiles (parameters 
 #' `spatial_cell_no` and `spatial_tile_no`) and which gcm cell to use for 
@@ -61,13 +64,19 @@ write_glm_output <- function(run_group, outfile_template) {
 #' site_id, driver, the name of the export feather file, its hash, the state 
 #' the lake is in, and (if GCM output) the GCM spatial_cell_no, spatial_tile_no, 
 #' data_cell_no, and data_tile_no for that lake.
-generate_output_tibble <- function(run_group, output_feather, lake_xwalk) {
+generate_output_tibble <- function(output_feathers, output_site_ids, driver_names, lake_xwalk) {
+  # collapse the site_ids and driver names vectors for use in string matching
+  site_id_list <- paste(output_site_ids,collapse="|")
+  driver_name_list <- paste(driver_names,collapse="|")
+  
+  # Build tibble of output files, hashes, driver, and site_id
   export_tibble <- tibble(
-      site_id = unique(run_group$site_id),
-      driver = unique(run_group$driver),
-      export_fl = output_feather,
-      export_fl_hash = tools::md5sum(output_feather)
-    ) %>% 
+    export_fl = output_feathers,
+    export_fl_hash = tools::md5sum(output_feathers),
+    site_id = stringr::str_extract(export_fl, site_id_list),
+    driver = stringr::str_extract(export_fl, driver_name_list)
+  ) %>%
+    select(site_id, driver, export_fl, export_fl_hash) %>%
     left_join(lake_xwalk, by='site_id')
   
   return(export_tibble)


### PR DESCRIPTION
Quick PR to drop the `targets` mapping when building the tibbles with export file information. It was really bogging down the pipeline when I expanded the GCM runs to the full footprint, and I realized the mapping wasn't actually necessary.