### PR TITLE
switch to regex in place of string matching

### DIFF
--- a/3_extract.R
+++ b/3_extract.R
@@ -27,8 +27,7 @@ p3 <- list(
   tar_target(
     p3_gcm_glm_uncalibrated_output_feather_tibble,
     generate_output_tibble(p3_gcm_glm_uncalibrated_output_feathers,
-                           output_site_ids = unique(p2_gcm_glm_uncalibrated_run_groups$site_id),
-                           driver_names = unique(p2_gcm_glm_uncalibrated_run_groups$driver),
+                           output_file_regex = "GLM_(.*)_(.*).feather",
                            lake_xwalk = p1_lake_cell_tile_xwalk_df)
   ),
   
@@ -85,8 +84,7 @@ p3 <- list(
   tar_target(
     p3_nldas_glm_uncalibrated_output_feather_tibble,
     generate_output_tibble(p3_nldas_glm_uncalibrated_output_feathers, 
-                           output_site_ids = unique(p2_nldas_glm_uncalibrated_run_groups$site_id),
-                           driver_names = unique(p2_nldas_glm_uncalibrated_run_groups$driver),
+                           output_file_regex = "GLM_(.*)_(.*).feather",
                            lake_xwalk = p1_lake_to_state_xwalk_df)
   ),
   

--- a/3_extract/src/process_glm_output.R
+++ b/3_extract/src/process_glm_output.R
@@ -50,7 +50,7 @@ write_glm_output <- function(run_group, outfile_template) {
 #' The function maps over these file names.
 #' @param output_file_regex regex pattern for the output files returned by
 #' `write_glm_output()` -- used to extract the site_id and driver of the
-#' output data. NOTE: must match pattern matching that used in `write_glm_output()`,
+#' output data. NOTE: must match the outfile_template used in `write_glm_output()`,
 #' currently that is 'GLM_{site_id}_{driver}.feather'
 #' @param lake_xwalk - If the passed runs are GCM runs, this xwalk is a 
 #' mapping of which lakes fall into which gcm cells and tiles (parameters 


### PR DESCRIPTION
This PR switches to using solely regex pattern matching to extract the `site_id` and `driver` from the output file names when building `p3_{driver type}_glm_uncalibrated_output_feather_tibble` for GCM and NLDAS runs. The previous approach (using `stringr::str_extract()` with a collapsed vector of site_ids caused a regex error (`Error in {min,max} interval. U_REGEX_BAD_INTERVAL`), we think b/c of the `{` in some site ids. The new approach is adapted from that Lindsay used [here](https://github.com/USGS-R/lake-temperature-out/blob/main/3_summarize/src/do_annual_thermal_metric_tasks.R#L37).