### PR TITLE
Use latest ncdfgeom

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ Here's how to get the image that Jesse built from Dockerhub and translate it to 
 
 ``` bash
 cd /caldera/projects/usgs/water/iidd/datasci/lake-temp/lake-temperature-process-models
-singularity pull docker://jrossusgs/glm3r:v0.7
-# now you can see the singularity image: it is a file called glm3r_v0.7.sif
+singularity pull docker://jrossusgs/glm3r:v0.7.1
+
+# Now you can see the singularity image: it is a file called glm3r_v0.7.1.sif.
+# Create a symlink so that the launch-rstudio-container.slurm points to the new
+# container.
+rm glm3r.sif
+ln -s glm3r_v0.7.1.sif glm3r.sif
 ```
 
 **Running the pipeline in the Singularity container**
@@ -56,12 +61,12 @@ Here's how to build targets using the Singularity container and the `targets::ta
 
 ``` r
 # Build GCM-driven GLM models, in parallel
-srun --pty -c 72 -t 7:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=60)'
+srun --pty -c 72 -t 7:00:00 -A watertemp singularity exec glm3r.sif Rscript -e 'targets::tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=60)'
 ```
 
 ``` r
 # Build NLDAS-driven GLM models, in parallel
-srun --pty -c 72 -t 1:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript -e 'targets::tar_make_clustermq(p2_nldas_glm_uncalibrated_runs, workers=60)'
+srun --pty -c 72 -t 1:00:00 -A watertemp singularity exec glm3r.sif Rscript -e 'targets::tar_make_clustermq(p2_nldas_glm_uncalibrated_runs, workers=60)'
 ```
 
 **Running the pipeline interactively**
@@ -69,7 +74,7 @@ srun --pty -c 72 -t 1:00:00 -A watertemp singularity exec glm3r_v0.7.sif Rscript
 Here's how to run the Singularity container interactively on an allocated job:
 
 ``` r
-srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r_v0.7.sif bash
+srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r.sif bash
 R
 library(targets)
 tar_make_clustermq(p2_gcm_glm_uncalibrated_runs, workers=72)
@@ -85,7 +90,7 @@ In git bash window:
 [hcorson-dosch@tg-login1 lake-temperature-process-models] umask 002
 [hcorson-dosch@tg-login1 lake-temperature-process-models] screen # set up screen so that if lose Pulse Secure connection, run continues
 [hcorson-dosch@tg-login1 lake-temperature-process-models] module load singularity slurm
-[hcorson-dosch@tg-login1 lake-temperature-process-models] srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r_v0.7.sif bash # Here I'm requesting 72 cores (1 node) for 10 hours
+[hcorson-dosch@tg-login1 lake-temperature-process-models] srun --pty -c 72 -t 10:00:00 -A watertemp singularity exec glm3r.sif bash # Here I'm requesting 72 cores (1 node) for 10 hours
 ```
 Once the resources have been allocated, you'll immediately be transferred to the allocated node, and will be in the container environment.
 
@@ -182,9 +187,9 @@ The pipeline can be run in parallel locally through docker, just as it can be ru
 Simple command-line R interface:
 
 ``` bash
-docker pull jrossusgs/glm3r:v0.7
+docker pull jrossusgs/glm3r:v0.7.1
 cd ~/lake-temperature-process-models
-docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -it jrossusgs/glm3r:v0.7 R
+docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -it jrossusgs/glm3r:v0.7.1 R
 # Now you have an R prompt in the container, with the project directory mounted at `/lakes/`.
 # You can `setwd("/lakes")` and start working.
 ```
@@ -192,9 +197,9 @@ docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -it jrossusg
 Or alternatively, you could run RStudio in the container and access it through your browser (user is rstudio, password set in the startup command as mypass).
 
 ``` bash
-docker pull jrossusgs/glm3r:v0.7
+docker pull jrossusgs/glm3r:v0.7.1
 cd ~/lake-temperature-process-models
-docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -p 8787:8787 -e PASSWORD=mypass -e ROOT=TRUE -d jrossusgs/glm3r:v0.7
+docker run -v '/home/jross/lake-temperature-process-models/:/lakes' -p 8787:8787 -e PASSWORD=mypass -e ROOT=TRUE -d jrossusgs/glm3r:v0.7.1
 ```
 
 ``` r

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN echo 'set visualbell' >> /root/.vimrc
 # Add DOI CA to local CAs so that SSL can work over VPN
 COPY DOIRootCA2.crt /usr/local/share/ca-certificates
 RUN update-ca-certificates
+ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 
 # Set a default scheduler for clustermq. This can be overridden in the
 # _targets.R itself. The multicore should be nice for saving memory as it is
@@ -22,7 +23,6 @@ RUN update-ca-certificates
 # instead of the one included with the package.
 RUN echo '\n\
 options(clustermq.scheduler = "multicore")\n\
-#options(repos = c(REPO_NAME = "https://rpkg.chs.usgs.gov/prod-cran/latest"))\n\
 Sys.setenv(GLM_PATH = "/usr/local/bin/GLM/glm")' \
   >> /usr/local/lib/R/etc/Rprofile.site
 
@@ -61,10 +61,12 @@ RUN git clone https://github.com/AquaticEcoDynamics/libplot.git && \
   cd .. && \
   rm -rf *
 
+# Install some packages which aren't on CRAN or aren't recent enough on CRAN
 RUN Rscript -e 'library(remotes); \
-                install_github("GLEON/GLMr"); \
-                install_github("GLEON/GLM3r"); \
-                install_github("GLEON/glmtools");' \
+                install_github("GLEON/GLMr", upgrade = "never"); \
+                install_github("GLEON/GLM3r", upgrade = "never"); \
+                install_github("GLEON/glmtools", upgrade = "never"); \
+                install_github("USGS-R/ncdfgeom", upgrade = "never");' \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Install the necessary pipeline and parallelization packages for R
@@ -73,7 +75,6 @@ RUN install2.r --error \
   clustermq \
   fst \
   igraph \
-  ncdfgeom \
   retry \
   RNetCDF \
   tarchetypes \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3.1"
 services:
   glm_test:
-    image: jrossusgs/glm3r:v0.7
+    image: jrossusgs/glm3r:v0.7.1
     build:
       context: .
+      cache_from:
+        - jrossusgs/glm3r:latest
     ports:
       - "8787:8787"
     volumes:

--- a/launch-rstudio-container.slurm
+++ b/launch-rstudio-container.slurm
@@ -88,7 +88,7 @@ When done using RStudio Server, terminate the job by:
 END
 
 module load singularity
-singularity exec  glm3r_v0.7.sif \
+singularity exec  glm3r.sif \
     bash -c "cp /usr/local/lib/R/etc/Renviron.site.orig /usr/local/lib/R/etc/Renviron.site; \
             echo SINGULARITY_CONTAINER=\$SINGULARITY_CONTAINER >> /usr/local/lib/R/etc/Renviron.site; \
             echo SINGULARITY_BIND=\$SINGULARITY_BIND >> /usr/local/lib/R/etc/Renviron.site; \

--- a/launch-rstudio-container.slurm
+++ b/launch-rstudio-container.slurm
@@ -53,6 +53,8 @@ touch ${workdir}/singularity_vars
 # https://github.com/rstudio/rstudio/blob/v1.4.1106/src/cpp/server/ServerSessionManager.cpp#L126
 export SINGULARITYENV_RSTUDIO_SESSION_TIMEOUT=0
 
+export SINGULARITYENV_USER=$(id -un)
+
 # Set the local directory as the place for session information. This should make
 # command line history more relevant, as it will be restricted to the project
 # currently being worked on.
@@ -60,15 +62,14 @@ export SINGULARITYENV_RSTUDIO_SESSION_TIMEOUT=0
 # Pointer here: https://support.rstudio.com/hc/en-us/articles/218730228-Resetting-a-user-s-state-on-RStudio-Workbench-RStudio-Server
 # RStudio Workbench admin guide here: https://docs.rstudio.com/ide/server-pro/r_sessions/customizing_session_settings.html
 # XDG Base Directory Specification here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-export SINGULARITYENV_XDG_DATA_HOME=$(pwd)/.local_${USER}/share
+export SINGULARITYENV_XDG_DATA_HOME=$(pwd)/.local_${SINGULARITYENV_USER}/share
 
-export SINGULARITYENV_USER=$(id -un)
 export SINGULARITYENV_PASSWORD=$(openssl rand -base64 15)
 # get unused socket per https://unix.stackexchange.com/a/132524
 # tiny race condition between the python & singularity commands
 readonly PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 cat 1>&2 <<END
-1. SSH tunnel from your workstation using the following command:
+1. FROM YOUR LOCAL WORKSTATION, make an ssh tunnel using the following command:
 
    ssh -N -L 8787:${HOSTNAME}:${PORT} ${SINGULARITYENV_USER}@tallgrass.cr.usgs.gov
 
@@ -92,9 +93,8 @@ singularity exec  glm3r.sif \
     bash -c "cp /usr/local/lib/R/etc/Renviron.site.orig /usr/local/lib/R/etc/Renviron.site; \
             echo SINGULARITY_CONTAINER=\$SINGULARITY_CONTAINER >> /usr/local/lib/R/etc/Renviron.site; \
             echo SINGULARITY_BIND=\$SINGULARITY_BIND >> /usr/local/lib/R/etc/Renviron.site; \
-            echo SLURM_JOB_CPUS_PER_NODE=\$SLURM_JOB_CPUS_PER_NODE >> /usr/local/lib/R/etc/Renviron.site; \
             rserver --www-port=${PORT} \
-                    --server-user=${USER} \
+                    --server-user=${SINGULARITYENV_USER} \
                     --auth-none=0 \
                     --auth-pam-helper-path=pam-helper \
                     --auth-stay-signed-in-days=30 \


### PR DESCRIPTION
This updates the docker image to use the latest version of `ncdfgeom` from github.

I also took the opportunity to make a few other changes to the container and SLURM launch script to make this repository consistent with others which are targeted towards the use of containerization on HPC; for details see [here](https://code.usgs.gov/wma/wp/pump-temperature/-/issues/34).

I built the docker image and pushed it to docker hub, and pulled the singularity image down to tallgrass. So, if you pull this branch down to tallgrass, it will run the new image.