### PR TITLE
Add R markdown summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ _targets
 */tmp/*
 */out/*
 
+# Allow the Rmarkdown run summary to be committed
+!3_extract/out/GLM_run_summary.Rmd
+
 # Allow the nml template to be committed
 !1_prep/in/glm3_template.nml
 

--- a/3_extract.R
+++ b/3_extract.R
@@ -118,5 +118,10 @@ p3 <- list(
     },
     format = 'file',
     pattern = map(p3_nldas_glm_uncalibrated_output_feather_groups)
-  )
+  ),
+  
+  ##### Generate combined run summary #####
+  tar_render(p3_run_summary,
+             '3_extract/out/GLM_run_summary.Rmd',
+             packages = c('knitr'))
 )

--- a/3_extract/out/GLM_run_summary.Rmd
+++ b/3_extract/out/GLM_run_summary.Rmd
@@ -1,0 +1,57 @@
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+options(tidyverse.quiet = TRUE)
+current_date <- Sys.Date()
+```
+---
+title: "Summary of GLM runs"
+output: html_document
+date: `r current_date`
+---
+
+### NLDAS runs
+``` {r, echo = FALSE}
+tar_load(p1_nldas_site_ids)
+tar_load(p1_lake_to_state_xwalk_df)
+tar_load(p2_nldas_glm_uncalibrated_runs)
+tar_load(p2_nldas_glm_uncalibrated_run_groups)
+tar_load(p3_nldas_glm_uncalibrated_output_feather_tibble)
+tar_load(p1_nldas_dates)
+
+nldas_timeperiod <- sprintf('%s to %s', p1_nldas_dates$driver_start_date, p1_nldas_dates$driver_end_date)
+nldas_run_summary <- p3_nldas_glm_uncalibrated_output_feather_tibble %>%
+  group_by(state) %>%
+  summarize(n_lakes = length(unique(site_id)), .groups='keep')
+```
+
+Using `r unique(p2_nldas_glm_uncalibrated_runs$driver)` driver data and GLM version `r unique(p2_nldas_glm_uncalibrated_runs$glm_version)`, we modeled `r length(p1_nldas_site_ids)` lakes across `r length(unique(p1_lake_to_state_xwalk_df$state))` states (`r unique(p1_lake_to_state_xwalk_df$state)`). For each lake, we modeled lake temperatures from `r nldas_timeperiod`. Models ran successfully for `r length(unique(p2_nldas_glm_uncalibrated_run_groups$site_id))` lakes.
+
+``` {r nldas_run_summary, echo = FALSE, results = 'asis'}
+library(knitr)
+kable(nldas_run_summary, caption = "Summary of successful NLDAS runs")
+```
+
+### GCM runs
+
+```{r, echo=FALSE}
+tar_load(p1_gcm_site_ids)
+tar_load(p1_lake_cell_tile_xwalk_df)
+tar_load(p2_gcm_glm_uncalibrated_runs)
+tar_load(p2_gcm_glm_uncalibrated_run_groups)
+tar_load(p3_gcm_glm_uncalibrated_output_feather_tibble)
+tar_load(p1_gcm_dates)
+
+gcm_timeperiod_1 <- sprintf('%s to %s', p1_gcm_dates$driver_start_date[1], p1_gcm_dates$driver_end_date[1])
+gcm_timeperiod_2 <- sprintf('%s to %s', p1_gcm_dates$driver_start_date[2], p1_gcm_dates$driver_end_date[2])
+gcm_timeperiod_3 <- sprintf('%s to %s', p1_gcm_dates$driver_start_date[3], p1_gcm_dates$driver_end_date[3])
+gcm_run_summary <- p3_gcm_glm_uncalibrated_output_feather_tibble %>%
+  group_by(state) %>%
+  summarize(n_lakes = length(unique(site_id)), .groups='keep')
+```
+
+Using driver data for `r length(unique(p2_gcm_glm_uncalibrated_runs$driver))` GCMs (`r unique(p2_gcm_glm_uncalibrated_runs$driver)`) and GLM version `r unique(p2_gcm_glm_uncalibrated_runs$glm_version)`, we modeled `r length(p1_gcm_site_ids)` lakes across `r length(unique(p1_lake_cell_tile_xwalk_df$state))` states (`r unique(p1_lake_cell_tile_xwalk_df$state)`). For each lake and each GCM, we modeled lake temperatures during three time periods: `r gcm_timeperiod_1`, `r gcm_timeperiod_2`, and `r gcm_timeperiod_3`. Models for all three time periods for all `r length(unique(p2_gcm_glm_uncalibrated_run_groups$driver))` GCMs ran successfully for `r length(unique(p2_gcm_glm_uncalibrated_run_groups$site_id))` lakes.
+
+``` {r gcm_run_summary, echo = FALSE, results = 'asis'}
+kable(gcm_run_summary, caption = "Summary of successful GCM runs")
+```

--- a/3_extract/out/GLM_run_summary.Rmd
+++ b/3_extract/out/GLM_run_summary.Rmd
@@ -14,8 +14,6 @@ date: `r current_date`
 ``` {r, echo = FALSE}
 tar_load(p1_nldas_site_ids)
 tar_load(p1_lake_to_state_xwalk_df)
-tar_load(p2_nldas_glm_uncalibrated_runs)
-tar_load(p2_nldas_glm_uncalibrated_run_groups)
 tar_load(p3_nldas_glm_uncalibrated_output_feather_tibble)
 tar_load(p1_nldas_dates)
 
@@ -25,7 +23,7 @@ nldas_run_summary <- p3_nldas_glm_uncalibrated_output_feather_tibble %>%
   summarize(n_lakes = length(unique(site_id)), .groups='keep')
 ```
 
-Using `r unique(p2_nldas_glm_uncalibrated_runs$driver)` driver data and GLM version `r unique(p2_nldas_glm_uncalibrated_runs$glm_version)`, we modeled `r length(p1_nldas_site_ids)` lakes across `r length(unique(p1_lake_to_state_xwalk_df$state))` states (`r unique(p1_lake_to_state_xwalk_df$state)`). For each lake, we modeled lake temperatures from `r nldas_timeperiod`. Models ran successfully for `r length(unique(p2_nldas_glm_uncalibrated_run_groups$site_id))` lakes.
+Using NLDAS driver data and GLM version `r GLM3r::glm_version(as_char = TRUE)`, we modeled `r length(p1_nldas_site_ids)` lakes across `r length(unique(p1_lake_to_state_xwalk_df$state))` states (`r unique(p1_lake_to_state_xwalk_df$state)`). For each lake, we modeled lake temperatures from `r nldas_timeperiod`. Models ran successfully for `r length(unique(p3_nldas_glm_uncalibrated_output_feather_tibble$site_id))` lakes.
 
 ``` {r nldas_run_summary, echo = FALSE, results = 'asis'}
 library(knitr)
@@ -37,8 +35,6 @@ kable(nldas_run_summary, caption = "Summary of successful NLDAS runs")
 ```{r, echo=FALSE}
 tar_load(p1_gcm_site_ids)
 tar_load(p1_lake_cell_tile_xwalk_df)
-tar_load(p2_gcm_glm_uncalibrated_runs)
-tar_load(p2_gcm_glm_uncalibrated_run_groups)
 tar_load(p3_gcm_glm_uncalibrated_output_feather_tibble)
 tar_load(p1_gcm_dates)
 
@@ -50,7 +46,7 @@ gcm_run_summary <- p3_gcm_glm_uncalibrated_output_feather_tibble %>%
   summarize(n_lakes = length(unique(site_id)), .groups='keep')
 ```
 
-Using driver data for `r length(unique(p2_gcm_glm_uncalibrated_runs$driver))` GCMs (`r unique(p2_gcm_glm_uncalibrated_runs$driver)`) and GLM version `r unique(p2_gcm_glm_uncalibrated_runs$glm_version)`, we modeled `r length(p1_gcm_site_ids)` lakes across `r length(unique(p1_lake_cell_tile_xwalk_df$state))` states (`r unique(p1_lake_cell_tile_xwalk_df$state)`). For each lake and each GCM, we modeled lake temperatures during three time periods: `r gcm_timeperiod_1`, `r gcm_timeperiod_2`, and `r gcm_timeperiod_3`. Models for all three time periods for all `r length(unique(p2_gcm_glm_uncalibrated_run_groups$driver))` GCMs ran successfully for `r length(unique(p2_gcm_glm_uncalibrated_run_groups$site_id))` lakes.
+Using driver data for `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver))` GCMs (`r unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver)`) and GLM version `r GLM3r::glm_version(as_char = TRUE)`, we modeled `r length(p1_gcm_site_ids)` lakes across `r length(unique(p1_lake_cell_tile_xwalk_df$state))` states (`r unique(p1_lake_cell_tile_xwalk_df$state)`). For each lake and each GCM, we modeled lake temperatures during three time periods: `r gcm_timeperiod_1`, `r gcm_timeperiod_2`, and `r gcm_timeperiod_3`. Models for all three time periods for all `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver))` GCMs ran successfully for `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$site_id))` lakes.
 
 ``` {r gcm_run_summary, echo = FALSE, results = 'asis'}
 kable(gcm_run_summary, caption = "Summary of successful GCM runs")

--- a/3_extract/out/GLM_run_summary.Rmd
+++ b/3_extract/out/GLM_run_summary.Rmd
@@ -27,7 +27,7 @@ Using NLDAS driver data and GLM version `r GLM3r::glm_version(as_char = TRUE)`, 
 
 ``` {r nldas_run_summary, echo = FALSE, results = 'asis'}
 library(knitr)
-kable(nldas_run_summary, caption = "Summary of successful NLDAS runs")
+kable(nldas_run_summary, caption = "Count of lakes with NLDAS-driven GLM predictions, by state")
 ```
 
 ### GCM runs
@@ -49,5 +49,28 @@ gcm_run_summary <- p3_gcm_glm_uncalibrated_output_feather_tibble %>%
 Using driver data for `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver))` GCMs (`r unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver)`) and GLM version `r GLM3r::glm_version(as_char = TRUE)`, we modeled `r length(p1_gcm_site_ids)` lakes across `r length(unique(p1_lake_cell_tile_xwalk_df$state))` states (`r unique(p1_lake_cell_tile_xwalk_df$state)`). For each lake and each GCM, we modeled lake temperatures during three time periods: `r gcm_timeperiod_1`, `r gcm_timeperiod_2`, and `r gcm_timeperiod_3`. Models for all three time periods for all `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$driver))` GCMs ran successfully for `r length(unique(p3_gcm_glm_uncalibrated_output_feather_tibble$site_id))` lakes.
 
 ``` {r gcm_run_summary, echo = FALSE, results = 'asis'}
-kable(gcm_run_summary, caption = "Summary of successful GCM runs")
+kable(gcm_run_summary, caption = "Count of lakes with GCM-driven GLM predictions, by state")
+```
+
+### Overall summary
+``` {r p3_nldas_glm_uncalibrated_output_feather_tibble, p3_gcm_glm_uncalibrated_output_feather_tibble, echo = FALSE}
+nldas_and_gcm_sites <- intersect(unique(p3_nldas_glm_uncalibrated_output_feather_tibble$site_id),
+                                 unique(p3_gcm_glm_uncalibrated_output_feather_tibble$site_id))
+
+run_all <- p3_gcm_glm_uncalibrated_output_feather_tibble %>%
+  group_by(site_id, state) %>%
+  summarize(n_GCM_models=n(), .groups='keep') %>%
+  inner_join(
+    p3_nldas_glm_uncalibrated_output_feather_tibble %>% group_by(site_id, state) %>%
+      summarize(n_NLDAS_models = n(), .groups='keep'),
+    by=c('site_id','state'))
+
+nldas_gcm_run_summary <- run_all %>%
+  group_by(state) %>%
+  summarize(n_lakes = length(unique(site_id)), .groups='keep') 
+```
+Overall, both NLDAS and GCM models ran successfully for `r length(nldas_and_gcm_sites)` lakes.
+
+``` {r nldas_gcm_run_summary, echo = FALSE, results = 'asis'}
+kable(nldas_gcm_run_summary, caption = "Count of lakes with NLDAS- and GCM-driven GLM predictions, by state")
 ```

--- a/_targets.R
+++ b/_targets.R
@@ -1,4 +1,5 @@
 library(targets)
+library(tarchetypes)
 options(clustermq.scheduler = "multicore")
 
 suppressPackageStartupMessages(library(tidyverse))


### PR DESCRIPTION
This PR adds a target that renders a R markdown file summarizing the NLDAS and GCM runs. I ended up connecting it into the pipeline since it was very straightforward (thanks, Julie, for linking to [the docs](https://books.ropensci.org/targets/literate-programming.html) in our standup earlier today).

I put in some basic summary language and stats, but am happy to add more if you'd like.

The summary that is generated is uploaded [here](https://doimspp.sharepoint.com/sites/IIDDStaff/Shared%20Documents/Project%20-%20Modeling%20Lakes/GLM/lake-temperature-process-models/GLM_run_summary.html). Here's a screenshot:
 
![image](https://user-images.githubusercontent.com/54007288/177435811-f5b391cd-6242-46de-b5c6-e0831c2002bd.png)
