### PR TITLE
Fix sim dir bug

### DIFF
--- a/1_prep/src/munge_meteo.R
+++ b/1_prep/src/munge_meteo.R
@@ -162,7 +162,7 @@ munge_gcm_dates <- function(gcm_ncs, gcm_time_periods, burn_in, burn_out) {
     time_period = date_to_gcm_time_period(time, gcm_time_periods)
     ) %>%
     group_by(time_period) %>%
-    summarize(driver_start_date = min(time), driver_end_date = max(time)) %>%
+    summarize(driver_start_date = min(time), driver_end_date = max(time), .groups='keep') %>%
     mutate(
       driver_type = 'gcm',
       # a burn-in period only will have been added if the requested burn-in period was 

--- a/2_run/src/run_glm3.R
+++ b/2_run/src/run_glm3.R
@@ -80,7 +80,11 @@ run_glm3_model <- function(sim_dir, nml_obj, model_config, export_fl_template) {
   raw_meteo_fl <- model_config$meteo_fl
   
   # prepare to write inputs and results locally for quick I/O
+  # if the run simulation directory already exists (b/c previous run for site failed), 
+  # delete the simulation directory before creating a new one, in order to have 
+  # a clean record of the current run
   sim_lake_dir <- file.path(sim_dir, sprintf('%s_%s_%s', site_id, driver, time_period))
+  if (dir.exists(sim_lake_dir)) unlink(sim_lake_dir, recursive = TRUE)
   dir.create(sim_lake_dir, recursive=TRUE, showWarnings=FALSE)
   
   # copy meteo data to sim_lake_dir


### PR DESCRIPTION
This fixes a bug in `run_glm3.R`, in which existing simulation directories (remaining from previous lake-gcm-time-period specific model runs that _failed_) were not deleted at the start of new model runs. As a result, the new simulation (edit: if that simulation had previously failed) ended up using the existing meteo csv within the simulation directory, as the [`file.copy` command to copy the meteo csv to the simulation directory](https://github.com/USGS-R/lake-temperature-process-models/blob/main/2_run/src/run_glm3.R#L88) did not have `overwrite=TRUE`.

The fix made here is to delete the simulation directory if it exists at the start of a new model run. This ensures that we have a fresh record of each model run and that the simulation directory is created and populated anew for each model run.

I also included one small change to keep the grouping by `time_period` when building `p1_gcm_dates` - for some reason this threw an error when I was testing my change locally, even though it has run fine previously. 