### PR TITLE
Combine steps to generate GCM output feathers and output tibble

### DIFF
--- a/3_extract.R
+++ b/3_extract.R
@@ -14,7 +14,7 @@ p3 <- list(
   tar_target(
     p3_gcm_glm_uncalibrated_output_feather_tibble,
     {
-      output_files <- p2_gcm_glm_uncalibrated_run_groups %>% # Already grouped by site_id
+      feather_tibble <- p2_gcm_glm_uncalibrated_run_groups %>% # Already grouped by site_id
         group_by(driver) %>% # Also group by driver (GCM) for creating export files
         group_modify(~ {
           output_file <- write_glm_output(.x, outfile_template='3_extract/out/GLM_%s_%s.feather')
@@ -24,7 +24,7 @@ p3 <- list(
             select(-driver)
         }, .keep=TRUE) %>%
         select(site_id, driver, export_fl, export_fl_hash, everything())
-      return(output_files)
+      return(feather_tibble)
     },
     pattern = map(p2_gcm_glm_uncalibrated_run_groups)),
   


### PR DESCRIPTION
This PR combines two separate targets that a) generated GCM model output feathers and b) generated the GCM model output tibble into a single target.

### Reason for change
This change was prompted by a recurring error on Tallgrass when trying to build `p3_gcm_glm_uncalibrated_output_tibble`. The error seemed to be tied to the vector of filepaths that was being passed as an argument `p3_gcm_glm_uncalibrated_output_feathers`. This code had [previously run without issue](https://github.com/USGS-R/lake-temperature-process-models/pull/71#issuecomment-1155378387). A few attempts to address the error failed, so this workaround was implemented. See details on the error, below.

______________________________
### Change

I've merged the steps to generate `p3_gcm_glm_uncalibrated_output_feathers` into the steps to build `p3_gcm_glm_uncalibrated_output_tibble`.

Now, for each site, for each GCM, we [generate an output file with model results **_and immediately_** build a one-row output tibble](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/gcm_output_alt_2/3_extract.R#L20-L23). This tibble documents the filepath and hash of the output file. This approach is similar to that used to build `p2_gcm_glm_uncalibrated_runs`, where a file generated in the function call is documented in a tibble, rather than returned as a file target.
_____________________________
### Details on the error
When working interactively, the error seemed to suggest an encoding issues:
  * When testing the `generate_output_tibble()` function with a subset of the file vector I got: 
  ![image](https://user-images.githubusercontent.com/54007288/188002963-0dcc7283-7b61-4c3e-805b-a10694b9845d.png)

  * When Lindsay loaded the  `p2_gcm_glm_uncalibrated_output_feathers` vector interactively she got this error: 
![image](https://user-images.githubusercontent.com/54007288/188002895-bccfacc0-6c2f-48b0-9663-636c87175bf5.png)

With slurm jobs, the error manifested as a memory allocation segmentation fault:
  * ![image](https://user-images.githubusercontent.com/54007288/188003342-52b5f4c1-f30e-4e85-afca-1e5101c840e9.png)

Specifying use of `singularity/3.3.0`, specifying an amount of memory in the sbatch call with `--mem`, adding the `--exclusive` flag, regenerating the vector of filepaths (in case it was corrupted), and [chunking the vector before calling `generate_output_tibble()`](https://github.com/hcorson-dosch/lake-temperature-process-models/blob/gcm_output_alt/3_extract.R#L30-L34) all failed to fix the error.